### PR TITLE
XD-455: During the maven publish task the test jar does replace the main jar

### DIFF
--- a/entity-store/build.gradle
+++ b/entity-store/build.gradle
@@ -6,13 +6,12 @@ dependencies {
 // do not build tests artifact if there is task 'uploadArchives' (fixes XD-406)
 if (!gradle.startParameter.getTaskNames().contains('uploadArchives')) {
     task jarTests(type: Jar) {
+        if (version.length() == 0) {
+            classifier = 'tests'
+        } else {
+            classifier = 'tests-' + version
+        }
         from project.sourceSets.test.output
-    }
-
-    if (version.length() == 0) {
-        jarTests.archiveName = rootProject.name + '-' + project.name + '-tests.jar'
-    } else {
-        jarTests.archiveName = rootProject.name + '-' + project.name + '-tests-' + version + '.jar'
     }
 
     artifacts {


### PR DESCRIPTION
When a gradle install the maven artefacts in the repo get overridden.