### PR TITLE
XD-580 Perform fsync before writing new DB root

### DIFF
--- a/environment/src/main/java/jetbrains/exodus/env/EnvironmentImpl.java
+++ b/environment/src/main/java/jetbrains/exodus/env/EnvironmentImpl.java
@@ -568,10 +568,6 @@ public class EnvironmentImpl implements Environment {
                 try {
                     final MetaTree[] tree = new MetaTree[1];
                     expiredLoggables = txn.doCommit(tree);
-                    // there is a temptation to postpone I/O in order to reduce number of writes to storage device,
-                    // but it's quite difficult to resolve all possible inconsistencies afterwards,
-                    // so think twice before removing the following line
-                    log.flush();
                     synchronized (metaLock) {
                         txn.setMetaTree(metaTree = tree[0]);
                         txn.executeCommitHook();

--- a/environment/src/main/java/jetbrains/exodus/io/AbstractDataWriter.java
+++ b/environment/src/main/java/jetbrains/exodus/io/AbstractDataWriter.java
@@ -36,6 +36,10 @@ public abstract class AbstractDataWriter implements DataWriter {
     }
 
     @Override
+    public void syncDirectory() {
+    }
+
+    @Override
     public final void close() {
         if (open) {
             closeImpl();

--- a/environment/src/main/java/jetbrains/exodus/io/DataWriter.java
+++ b/environment/src/main/java/jetbrains/exodus/io/DataWriter.java
@@ -27,6 +27,8 @@ public interface DataWriter extends Closeable {
 
     void sync();
 
+    void syncDirectory();
+
     @Override
     void close();
 

--- a/environment/src/main/java/jetbrains/exodus/io/FileDataWriter.java
+++ b/environment/src/main/java/jetbrains/exodus/io/FileDataWriter.java
@@ -32,6 +32,8 @@ public class FileDataWriter extends AbstractDataWriter {
     @NotNull
     private final File dir;
     @NotNull
+    private final FileChannel dirChannel;
+    @NotNull
     private final LockingManager lockingManager;
     @Nullable
     private RandomAccessFile file;
@@ -39,6 +41,11 @@ public class FileDataWriter extends AbstractDataWriter {
     public FileDataWriter(final File directory) {
         file = null;
         dir = directory;
+        try {
+            dirChannel = FileChannel.open(dir.toPath());
+        } catch (IOException e) {
+            throw new ExodusException("Cannot open the environment directory.", e);
+        }
         lockingManager = new LockingManager(dir);
     }
 
@@ -113,6 +120,15 @@ public class FileDataWriter extends AbstractDataWriter {
             if (file.getChannel().isOpen()) {
                 throw new ExodusException(ioe);
             }
+        }
+    }
+
+    @Override
+    public void syncDirectory() {
+        try {
+            dirChannel.force(false);
+        } catch (IOException e) {
+            throw new ExodusException("Cannot fsync directory", e);
         }
     }
 }

--- a/environment/src/main/java/jetbrains/exodus/log/BufferedDataWriter.java
+++ b/environment/src/main/java/jetbrains/exodus/log/BufferedDataWriter.java
@@ -183,6 +183,11 @@ class BufferedDataWriter implements TransactionalDataWriter {
     }
 
     @Override
+    public void syncDirectory() {
+        child.syncDirectory();
+    }
+
+    @Override
     public void close() {
         if (count > 0) {
             throw new IllegalStateException("Can't close uncommitted writer " + count);

--- a/environment/src/main/java/jetbrains/exodus/log/Log.java
+++ b/environment/src/main/java/jetbrains/exodus/log/Log.java
@@ -897,7 +897,11 @@ public final class Log implements Closeable {
     private void createNewFileIfNecessary() {
         final boolean shouldCreateNewFile = getLastFileLength() == 0;
         if (shouldCreateNewFile) {
-            flush();
+            // fsync the old file to make sure the new database root is written only after all other transaction data
+            // were persisted to disk. Without it there is a significant risk of getting corrupted database on
+            // a system failure, because the OS is allowed to write cached file pages to disk out of order.
+            flush(true);
+
             bufferedWriter.close();
             if (config.isFullFileReadonly()) {
                 final Long lastFile;

--- a/environment/src/main/java/jetbrains/exodus/log/Log.java
+++ b/environment/src/main/java/jetbrains/exodus/log/Log.java
@@ -859,6 +859,9 @@ public final class Log implements Closeable {
                 }
             }
             if (fileCreated) {
+                // fsync the directory to ensure we will find the log file in the directory after system crash
+                bufferedWriter.syncDirectory();
+
                 notifyFileCreated(fileAddress);
             }
         }


### PR DESCRIPTION
We need to perform `fsync` before writing a new database root to ensure that the database root is written only after all other transaction data were persisted to disk. Without it there is a significant risk of getting corrupted database on a system failure, because the OS is free to persist cached file pages to disk out of order.

Most probably the `fsync` will cause some performance degradation, but I guess reliability is more important.