### PR TITLE
Update Kotlin to 1.2.21 and source version to 1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.0'
+    ext.kotlinVersion = '1.2.21'
     ext.dokkaVersion = '0.9.15'
     repositories { jcenter() }
     dependencies {
@@ -125,14 +125,14 @@ subprojects {
     }
     compileKotlin {
         kotlinOptions {
-            languageVersion = '1.1'
-            apiVersion = '1.1'
+            languageVersion = '1.2'
+            apiVersion = '1.2'
         }
     }
     compileTestKotlin {
         kotlinOptions {
-            languageVersion = '1.1'
-            apiVersion = '1.1'
+            languageVersion = '1.2'
+            apiVersion = '1.2'
         }
     }
     sourceJar {


### PR DESCRIPTION
Thanks for Xodus - I like it :)
I've updated the version of Kotlin to use the current build 1.2.21, this makes integration into projects easier (no libraries of different versions included).
Tests are passing here.