### PR TITLE
File descriptors leaking issue fix

### DIFF
--- a/environment/src/main/kotlin/jetbrains/exodus/io/FileDataWriter.kt
+++ b/environment/src/main/kotlin/jetbrains/exodus/io/FileDataWriter.kt
@@ -114,6 +114,8 @@ open class FileDataWriter @JvmOverloads constructor(private val reader: FileData
         try {
             (this.file ?: throw ExodusException("Can't close already closed FileDataWriter")).close()
             this.file = null
+            this.dirChannel?.close()
+            this.dirChannel = null
         } catch (e: IOException) {
             throw ExodusException("Can't close FileDataWriter", e)
         }


### PR DESCRIPTION
Hello! I've faced with such problem. If you try to recreate environment several times you'll see file descriptors count increasing. According to  `lsof -p <pid>` I've found `dirChannel` hasn't been closing at all. So, I hope it'll help.