### PR TITLE
Tune info level logging

### DIFF
--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
@@ -1936,7 +1936,9 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
 
     @Override
     public void close() {
-        logger.info("Closing...");
+        if(logger.isDebugEnabled()) {
+            logger.debug("Closing...");
+        }
         config.removeChangedSettingsListener(entityStoreSettingsListener);
         if (configMBean != null) {
             configMBean.unregister();
@@ -1954,7 +1956,9 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
                 }
             }
             iterableCache.clear();
-            logger.info("Closed successfully.");
+            if(logger.isDebugEnabled()) {
+                logger.debug("Closed successfully.");
+            }
         } catch (Exception e) {
             logger.error("close() failed", e);
             throw ExodusException.toExodusException(e);


### PR DESCRIPTION
Only log production relevant information on INFO level and so avoid cluttering log output.

I want to use xodus in an environment where I can not control the log configuration and therefore can not fine tune / change the log level of a 3rd party library.