### PR TITLE
Check additional ClassLoader for services

### DIFF
--- a/openAPI/src/main/java/jetbrains/exodus/crypto/StreamCipherProvider.java
+++ b/openAPI/src/main/java/jetbrains/exodus/crypto/StreamCipherProvider.java
@@ -55,7 +55,11 @@ public abstract class StreamCipherProvider {
      */
     @Nullable
     public static StreamCipherProvider getProvider(@NotNull final String id) {
-        for (final StreamCipherProvider provider : ServiceLoader.load(StreamCipherProvider.class)) {
+        ServiceLoader<StreamCipherProvider> serviceLoader = ServiceLoader.load(StreamCipherProvider.class);
+        if (!serviceLoader.iterator().hasNext()) {
+            serviceLoader = ServiceLoader.load(StreamCipherProvider.class, StreamCipherProvider.class.getClassLoader());
+        }
+        for (final StreamCipherProvider provider : serviceLoader) {
             if (id.equalsIgnoreCase(provider.getId())) {
                 return provider;
             }

--- a/openAPI/src/main/java/jetbrains/exodus/io/DataReaderWriterProvider.java
+++ b/openAPI/src/main/java/jetbrains/exodus/io/DataReaderWriterProvider.java
@@ -96,7 +96,11 @@ public abstract class DataReaderWriterProvider {
      */
     @Nullable
     public static DataReaderWriterProvider getProvider(@NotNull final String providerName) {
-        for (DataReaderWriterProvider provider : ServiceLoader.load(DataReaderWriterProvider.class)) {
+        ServiceLoader<DataReaderWriterProvider> serviceLoader = ServiceLoader.load(DataReaderWriterProvider.class);
+        if (!serviceLoader.iterator().hasNext()) {
+            serviceLoader = ServiceLoader.load(DataReaderWriterProvider.class, DataReaderWriterProvider.class.getClassLoader());
+        }
+        for (DataReaderWriterProvider provider : serviceLoader) {
             if (provider.getClass().getCanonicalName().equalsIgnoreCase(providerName)) {
                 return provider;
             }


### PR DESCRIPTION
This PR fixes the following exception in environments where `Thread.currentThread().getContextClassLoader()` is not the right `ClassLoader` for these services.

```
jetbrains.exodus.InvalidSettingException: Unknown DataReaderWriterProvider: jetbrains.exodus.io.FileDataReaderWriterProvider
	at jetbrains.exodus.log.LogConfig.getReaderWriterProvider(LogConfig.java:302) ~[?:?]
	at jetbrains.exodus.env.Environments.newLogInstance(Environments.java:117) ~[?:?]
	at jetbrains.exodus.env.Environments.newLogInstance(Environments.java:105) ~[?:?]
	at jetbrains.exodus.env.Environments.newInstance(Environments.java:60) ~[?:?]
	at jetbrains.exodus.entitystore.PersistentEntityStores.newInstance(PersistentEntityStores.java:64) ~[?:?]
	at jetbrains.exodus.entitystore.PersistentEntityStores.newInstance(PersistentEntityStores.java:70) ~[?:?]
```

The `getProvider` method in both `StreamCipherProvider` and `DataReaderWriterProvider` have been modified to search an additional `ClassLoader` if the first check does not return any classes