### PR TITLE
Disable management in Android; #XD-655

### DIFF
--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreConfig.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreConfig.java
@@ -651,7 +651,7 @@ public class PersistentEntityStoreConfig extends AbstractConfig {
     }
 
     public PersistentEntityStoreConfig setManagementEnabled(final boolean managementEnabled) {
-        return setSetting(MANAGEMENT_ENABLED, managementEnabled);
+        return setSetting(MANAGEMENT_ENABLED, managementEnabled && !JVMConstants.getIS_ANDROID());
     }
 
     public PersistentEntityStoreConfig setStoreReplicator(final PersistentEntityStoreReplicator replicator) {


### PR DESCRIPTION
This change disables Management in PersistentEntityStoreConfig by default.

This is done the same way as in EnvironmentConfig.

This change relates to issue XD-655.