### PR TITLE
Fixed typo in license URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ subprojects {
                             licenses {
                                 license {
                                     name 'The Apache Software License, Version 2.0'
-                                    url 'http://www.apache.org/license/LICENSE-2.0.txt'
+                                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                                     distribution 'repo'
                                 }
                             }


### PR DESCRIPTION
The URL for the license is incorrect (missing `s`) and should probably use https instead