### PR TITLE
Issue #XD-904 fixed

### DIFF
--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVaultOld.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVaultOld.java
@@ -150,9 +150,14 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
 
     @Override
     @Nullable
-    public InputStream getContent(final long blobHandle, @NotNull final Transaction txn) {
+    public InputStream getContent(final long blobHandle, @NotNull final Transaction txn, @Nullable Long expectedLength) {
         try {
-            return new FileInputStream(getBlobLocation(blobHandle));
+            var location = getBlobLocation(blobHandle);
+            if (expectedLength != null && location.length() != expectedLength.longValue()) {
+                return null;
+            }
+
+            return new FileInputStream(location);
         } catch (FileNotFoundException e) {
             return null;
         }

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreBackupStrategy.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreBackupStrategy.java
@@ -76,7 +76,9 @@ public class PersistentEntityStoreBackupStrategy extends BackupStrategy {
             if (blobVault instanceof FileSystemBlobVault) {
                 lastUsedHandle = store.getSequence(txn,
                         PersistentEntityStoreImpl.BLOB_HANDLES_SEQUENCE).loadValue(txn);
+                store.ensureBlobsConsistency(txn);
             }
+
         } finally {
             txn.abort();
         }
@@ -84,7 +86,7 @@ public class PersistentEntityStoreBackupStrategy extends BackupStrategy {
 
     @Override
     public Iterable<VirtualFileDescriptor> getContents() {
-        return () -> new Iterator<VirtualFileDescriptor>() {
+        return () -> new Iterator<>() {
 
             private Iterator<VirtualFileDescriptor> filesIterator = environmentBackupStrategy.getContents().iterator();
             private boolean environmentListed = false;

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentStoreTransaction.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentStoreTransaction.java
@@ -27,6 +27,7 @@ import jetbrains.exodus.core.dataStructures.ObjectCacheDecorator;
 import jetbrains.exodus.core.dataStructures.hash.LongHashMap;
 import jetbrains.exodus.core.dataStructures.hash.LongHashSet;
 import jetbrains.exodus.core.dataStructures.hash.LongSet;
+import jetbrains.exodus.core.execution.locks.Semaphore;
 import jetbrains.exodus.entitystore.iterate.*;
 import jetbrains.exodus.env.*;
 import jetbrains.exodus.util.StringBuilderSpinAllocator;

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/VFSBlobVault.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/VFSBlobVault.java
@@ -92,8 +92,16 @@ public class VFSBlobVault extends BlobVault {
     }
 
     @Override
-    @NotNull
-    public InputStream getContent(long blobHandle, @NotNull final Transaction txn) {
+    @Nullable
+    public InputStream getContent(long blobHandle, @NotNull final Transaction txn, @Nullable Long expectedLength) {
+        if (expectedLength != null) {
+            var actualLength = fs.getFileLength(txn, blobHandle);
+
+            if (actualLength != expectedLength.longValue()) {
+                return null;
+            }
+        }
+
         return fs.readFile(txn, blobHandle);
     }
 
@@ -178,7 +186,7 @@ public class VFSBlobVault extends BlobVault {
                 if (i++ % 100 == 0) {
                     txn.flush();
                 }
-                final InputStream content = sourceVault.getContent(blobId, txn);
+                final InputStream content = sourceVault.getContent(blobId, txn, null);
                 if (content != null) {
                     importBlob(txn, blobId, content);
                 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/crypto/EncryptedBlobVault.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/crypto/EncryptedBlobVault.kt
@@ -42,8 +42,12 @@ class EncryptedBlobVault(private val decorated: FileSystemBlobVaultOld,
         return decorated.getBlob(blobHandle)
     }
 
-    override fun getContent(blobHandle: Long, txn: Transaction): InputStream? {
-        return decorated.getContent(blobHandle, txn)?.run {
+    override fun getContent(
+        blobHandle: Long,
+        txn: Transaction,
+        expectedLength: Long?
+    ): InputStream? {
+        return decorated.getContent(blobHandle, txn, expectedLength)?.run {
             StreamCipherInputStream(this) {
                 newCipher(blobHandle)
             }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/DummyBlobVault.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/DummyBlobVault.kt
@@ -33,7 +33,11 @@ class DummyBlobVault(config: PersistentEntityStoreConfig) : BlobVault(config) {
 
     override fun getBackupStrategy() = throw NotImplementedError()
 
-    override fun getContent(blobHandle: Long, txn: Transaction) = throw NotImplementedError()
+    override fun getContent(
+        blobHandle: Long,
+        txn: Transaction,
+        expectedLength: Long?
+    ) = throw NotImplementedError()
 
     override fun getSize(blobHandle: Long, txn: Transaction) = throw NotImplementedError()
 

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/EntityBlobTests.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/EntityBlobTests.kt
@@ -233,7 +233,7 @@ class EntityBlobTests : EntityStoreTestBase() {
         }
         store.executeInReadonlyTransaction { txn ->
             txn as PersistentStoreTransaction
-            val content = store.blobVault.getContent(0, txn.environmentTransaction)
+            val content = store.blobVault.getContent(0, txn.environmentTransaction, null)
             assertNotNull(content)
             try {
                 content?.close()
@@ -244,7 +244,8 @@ class EntityBlobTests : EntityStoreTestBase() {
         store.clear()
         store.executeInReadonlyTransaction { txn ->
             assertNull(store.blobVault
-                .getContent(0, (txn as PersistentStoreTransaction).environmentTransaction))
+                .getContent(0, (txn as PersistentStoreTransaction).environmentTransaction,
+                    null))
         }
     }
 

--- a/environment/src/main/kotlin/jetbrains/exodus/io/FileDataWriter.kt
+++ b/environment/src/main/kotlin/jetbrains/exodus/io/FileDataWriter.kt
@@ -86,6 +86,9 @@ open class FileDataWriter @JvmOverloads constructor(
         return lockingManager.lock(timeout)
     }
 
+    fun lockFilePath() = lockingManager.lockFilePath()
+
+
     override fun release(): Boolean {
         return lockingManager.release()
     }

--- a/environment/src/main/kotlin/jetbrains/exodus/io/LockingManager.kt
+++ b/environment/src/main/kotlin/jetbrains/exodus/io/LockingManager.kt
@@ -129,6 +129,9 @@ internal class LockingManager internal constructor(private val dir: File, privat
         return File(dir, LOCK_FILE_NAME)
     }
 
+    fun lockFilePath() = getLockFile().absolutePath
+
+
     private fun throwFailedToLock(e: IOException): Boolean {
         if (usableSpace < 4096) {
             throw OutOfDiskSpaceException(e)

--- a/environment/src/main/kotlin/jetbrains/exodus/log/Log.kt
+++ b/environment/src/main/kotlin/jetbrains/exodus/log/Log.kt
@@ -29,6 +29,7 @@ import mu.KLogging
 import java.io.Closeable
 import java.util.concurrent.Semaphore
 import kotlin.experimental.xor
+import kotlin.text.StringBuilder
 
 class Log(val config: LogConfig, expectedEnvironmentVersion: Int) : Closeable {
 
@@ -979,10 +980,14 @@ class Log(val config: LogConfig, expectedEnvironmentVersion: Int) : Closeable {
         if (!config.isLockIgnored) {
             val lockTimeout = config.lockTimeout
             if (!dataWriter.lock(lockTimeout)) {
-                throw ExodusException(
-                    "Can't acquire environment lock after " +
-                            lockTimeout + " ms.\n\n Lock owner info: \n" + dataWriter.lockInfo()
-                )
+                val exceptionMessage = StringBuilder()
+                exceptionMessage.append(
+                    "Can't acquire environment lock after "
+                ).append(lockTimeout).append(" ms.\n\n Lock owner info: \n").append(dataWriter.lockInfo())
+                if (dataWriter is FileDataWriter) {
+                    exceptionMessage.append("\n Lock file path: ").append(dataWriter.lockFilePath())
+                }
+                throw ExodusException(exceptionMessage.toString())
             }
         }
     }

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/BlobVault.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/BlobVault.java
@@ -52,7 +52,7 @@ public abstract class BlobVault implements BlobHandleGenerator, Backupable {
     private static final int READ_BUFFER_SIZE = 0x4000;
     static final ByteArraySpinAllocator bufferAllocator = new ByteArraySpinAllocator(READ_BUFFER_SIZE);
     private static final BlobStringsCache.BlobStringsCacheCreator
-        stringContentCacheCreator = new BlobStringsCache.BlobStringsCacheCreator();
+            stringContentCacheCreator = new BlobStringsCache.BlobStringsCacheCreator();
     private static final IdGenerator identityGenerator = new IdGenerator();
 
     private final PersistentEntityStoreConfig config;
@@ -68,8 +68,8 @@ public abstract class BlobVault implements BlobHandleGenerator, Backupable {
     protected BlobVault(@NotNull final PersistentEntityStoreConfig config) {
         this.config = config;
         stringContentCache = config.isBlobStringsCacheShared() ?
-            stringContentCacheCreator.getInstance() :
-            new BlobStringsCache.BlobStringsCacheCreator().getInstance();
+                stringContentCacheCreator.getInstance() :
+                new BlobStringsCache.BlobStringsCacheCreator().getInstance();
         vaultIdentity = identityGenerator.nextId();
     }
 
@@ -114,13 +114,17 @@ public abstract class BlobVault implements BlobHandleGenerator, Backupable {
     /**
      * Returns binary content of blob identified by specified blob handle as {@linkplain InputStream}.
      *
-     * @param blobHandle blob handle
-     * @param txn        {@linkplain Transaction} instance
+     * @param blobHandle     blob handle
+     * @param txn            {@linkplain Transaction} instance
+     * @param expectedLength Expected size of content in bytes.
+     *                       If sizes do not match {@code null} will be returned.
+     *                       Can be {@code null} in such case content length verification will be bypassed.
      * @return binary content of blob as {@linkplain InputStream}
      * @see Entity#getBlob(String)
      */
     @Nullable
-    public abstract InputStream getContent(final long blobHandle, @NotNull final Transaction txn);
+    public abstract InputStream getContent(final long blobHandle, @NotNull final Transaction txn,
+                                           @Nullable Long expectedLength);
 
     /**
      * Returns size of blob identified by specified blob handle in bytes.
@@ -191,22 +195,21 @@ public abstract class BlobVault implements BlobHandleGenerator, Backupable {
     /**
      * Returns string content of blob identified by specified blob handle. String contents cache is used.
      *
-     * @param blobHandle blob handle
-     * @param txn        {@linkplain Transaction} instance
+     * @param blobHandle        blob handle
+     * @param txn               {@linkplain Transaction} instance
+     * @param expectedRawLength Expected size of the blob in bytes.
+     *                          If sizes do not match {@code null} will be returned.
+     *                          Can be {@code null} in such case content length verification will be bypassed.
      * @return string content of blob identified by specified blob handle
      * @throws IOException if something went wrong
      */
     @Nullable
-    public final String getStringContent(final long blobHandle, @NotNull final Transaction txn) throws IOException {
+    public final String getStringContent(final long blobHandle, @NotNull final Transaction txn,
+                                         @Nullable Long expectedRawLength) throws IOException {
         String result;
         result = stringContentCache.tryKey(this, blobHandle);
         if (result == null) {
-            final InputStream content = getContent(blobHandle, txn);
-            if (content == null) {
-                if (logger.isWarnEnabled()) {
-                    logger.warn("Blob string not found: " + getBlobLocation(blobHandle), new FileNotFoundException());
-                }
-            }
+            final InputStream content = getContent(blobHandle, txn, expectedRawLength);
             result = content == null ? null : UTFUtil.readUTF(content);
             if (result != null && result.length() <= config.getBlobStringsCacheMaxValueSize()) {
                 if (stringContentCache.getObject(this, blobHandle) == null) {

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/DiskBasedBlobVault.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/DiskBasedBlobVault.java
@@ -32,7 +32,8 @@ public interface DiskBasedBlobVault {
 
     boolean delete(long blobHandle);
 
-    @Nullable InputStream getContent(long blobHandle, @NotNull Transaction txn);
+    @Nullable InputStream getContent(long blobHandle, @NotNull Transaction txn,
+                                     @Nullable Long expectedContentLength);
 
     long size();
 


### PR DESCRIPTION
Issue #XD-904 fixed
When using the file system for storing blobs, writing the blob's content is performed
after committing metadata in the Xodus Environment. That implies a delay between transaction acknowledgement
and the actual writing of data which can cause situation when blob content can be incorrectly read in
another thread. To avoid such situations blob content is checked before returning to the user.
If the content is incomplete, the thread will wait a specified time in seconds until
the transaction wholly writes blob content. Otherwise, an exception will be thrown.
