### PR TITLE
Issue XD-908 was fixed.

### DIFF
--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVault.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVault.java
@@ -15,6 +15,7 @@
  */
 package jetbrains.exodus.entitystore;
 
+import jetbrains.exodus.env.Environment;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -24,12 +25,13 @@ public class FileSystemBlobVault extends FileSystemBlobVaultOld {
 
     private static final int EXPECTED_VERSION = 1;
 
-    public FileSystemBlobVault(@NotNull final PersistentEntityStoreConfig config,
+    public FileSystemBlobVault(@NotNull Environment environment,
+                               @NotNull final PersistentEntityStoreConfig config,
                                @NotNull final String parentDirectory,
                                @NotNull final String blobsDirectory,
                                @NotNull final String blobExtension,
                                @NotNull final BlobHandleGenerator blobHandleGenerator) throws IOException {
-        super(config, parentDirectory, blobsDirectory, blobExtension, blobHandleGenerator, EXPECTED_VERSION);
+        super(environment, config, parentDirectory, blobsDirectory, blobExtension, blobHandleGenerator, EXPECTED_VERSION);
     }
 
     @NotNull

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVaultOld.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVaultOld.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVaultOld.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVaultOld.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * https://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,11 +34,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVault {
-
     protected static final Logger logger = LoggerFactory.getLogger("FileSystemBlobVault");
 
     @NonNls
@@ -57,21 +62,27 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
     @Nullable
     private VaultSizeFunctions sizeFunctions;
 
+    private volatile Path tmpBlobsDir;
+
+    private final Lock tmpBlobDirLock = new ReentrantLock();
+
     /**
      * Blob size is calculated by inspecting directory files only on first request
      * After that, it's been calculated incrementally
      */
     private final AtomicLong size;
 
-    FileSystemBlobVaultOld(@NotNull final PersistentEntityStoreConfig config,
+    FileSystemBlobVaultOld(@NotNull Environment environment,
+                           @NotNull final PersistentEntityStoreConfig config,
                            @NotNull final String parentDirectory,
                            @NotNull final String blobsDirectory,
                            @NotNull final String blobExtension,
                            @NotNull final BlobHandleGenerator blobHandleGenerator) throws IOException {
-        this(config, parentDirectory, blobsDirectory, blobExtension, blobHandleGenerator, EXPECTED_VERSION);
+        this(environment, config, parentDirectory, blobsDirectory, blobExtension, blobHandleGenerator, EXPECTED_VERSION);
     }
 
-    FileSystemBlobVaultOld(@NotNull final PersistentEntityStoreConfig config,
+    FileSystemBlobVaultOld(@NotNull Environment environment,
+                           @NotNull final PersistentEntityStoreConfig config,
                            @NotNull final String parentDirectory,
                            @NotNull final String blobsDirectory,
                            @NotNull final String blobExtension,
@@ -107,6 +118,8 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
                 output.writeInt(expectedVersion);
             }
         }
+
+        generateDirForTmpBlobs(environment);
     }
 
     @Override
@@ -143,6 +156,19 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
                 setContentImpl(content, location);
             }
         }
+        if (size.get() != UNKNOWN_SIZE) {
+            size.addAndGet(IOUtil.getAdjustedFileLength(location));
+        }
+    }
+
+    private void setContent(final long blobHandle, @NotNull final Path file) throws Exception {
+        final File location = getBlobLocation(blobHandle, false);
+        try {
+            Files.move(file, location.toPath(), StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(file, location.toPath());
+        }
+
         if (size.get() != UNKNOWN_SIZE) {
             size.addAndGet(IOUtil.getAdjustedFileLength(location));
         }
@@ -186,7 +212,7 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
     @Override
     public void flushBlobs(@Nullable final LongHashMap<InputStream> blobStreams,
                            @Nullable final LongHashMap<File> blobFiles,
-                           @Nullable final LongSet deferredBlobsToDelete,
+                           @Nullable LongHashMap<Path> tmpBlobs, @Nullable final LongSet deferredBlobsToDelete,
                            @NotNull final Transaction txn) throws Exception {
         if (blobStreams != null) {
             blobStreams.forEachEntry((ObjectProcedureThrows<Map.Entry<Long, InputStream>, Exception>) object -> {
@@ -196,6 +222,7 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
                 return true;
             });
         }
+
         // if there were blob files then move them
         if (blobFiles != null) {
             blobFiles.forEachEntry((ObjectProcedureThrows<Map.Entry<Long, File>, Exception>) object -> {
@@ -203,6 +230,15 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
                 return true;
             });
         }
+
+        // if there were temporary stored blob files then move them
+        if (tmpBlobs != null) {
+            tmpBlobs.forEachEntry((ObjectProcedureThrows<Map.Entry<Long, Path>, Exception>) object -> {
+                setContent(object.getKey().longValue(), object.getValue());
+                return true;
+            });
+        }
+
         // if there are deferred blobs to delete then defer their deletion
         if (deferredBlobsToDelete != null) {
             final LongArrayList copy = new LongArrayList(deferredBlobsToDelete.size());
@@ -250,6 +286,7 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
 
     @Override
     public void close() {
+        IOUtil.deleteRecursively(location);
     }
 
     @NotNull
@@ -291,7 +328,7 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
                                     }
                                 } else if (file.exists()) {
                                     // something strange with filesystem
-                                    throw new EntityStoreException("File or directory expected: " + file.toString());
+                                    throw new EntityStoreException("File or directory expected: " + file);
                                 }
                             }
                             if (queue.isEmpty()) {
@@ -336,6 +373,18 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
         return blobsDirectory + super.getBlobKey(blobHandle) + blobExtension;
     }
 
+    @Override
+    public @NotNull Path copyToTemporaryStore(long handle, @NotNull final InputStream stream) throws IOException {
+        var tempFile = Files.createTempFile(tmpBlobsDir, "xodus", "blob-vault");
+
+        try (var out = Files.newOutputStream(tempFile)) {
+            IOUtil.copyStreams(stream, out, IOUtil.getBUFFER_ALLOCATOR());
+        }
+        stream.close();
+
+        return tempFile;
+    }
+
     @NotNull
     public File getBlobLocation(long blobHandle, boolean readonly) {
         File dir = location;
@@ -373,6 +422,8 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
         try (OutputStream blobOutput = new BufferedOutputStream(new FileOutputStream(location))) {
             IOUtil.copyStreams(content, blobOutput, bufferAllocator);
         }
+
+        content.close();
     }
 
     private long calculateBlobVaultSize() {
@@ -389,6 +440,21 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
             deleteRecursively(dir);
         }
         return true;
+    }
+
+    public void generateDirForTmpBlobs(Environment environment) throws IOException {
+        tmpBlobDirLock.lock();
+        try {
+            var newTmpDir = Files.createTempDirectory("blob-vault-for-" + location.getName());
+            if (tmpBlobsDir != null) {
+                environment.executeTransactionSafeTask(() -> IOUtil.deleteRecursively(tmpBlobsDir.toFile()));
+            }
+            tmpBlobsDir = newTmpDir;
+
+            logger.info("Temporary directory " + tmpBlobsDir + " has been created for blob vault " + location);
+        } finally {
+            tmpBlobDirLock.unlock();
+        }
     }
 
     private static boolean isEmptyDir(@NotNull final File dir) {

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * https://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -418,16 +418,16 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
             final PersistentSequenceBlobHandleGenerator.PersistentSequenceGetter persistentSequenceGetter =
                     () -> getSequence(getAndCheckCurrentTransaction(), BLOB_HANDLES_SEQUENCE);
             try {
-                blobVault = new FileSystemBlobVault(config, location, BLOBS_DIR, BLOBS_EXTENSION,
+                blobVault = new FileSystemBlobVault(environment, config, location, BLOBS_DIR, BLOBS_EXTENSION,
                         new PersistentSequenceBlobHandleGenerator(persistentSequenceGetter));
             } catch (UnexpectedBlobVaultVersionException e) {
                 blobVault = null;
             }
             if (blobVault == null) {
                 if (config.getMaxInPlaceBlobSize() > 0) {
-                    blobVault = new FileSystemBlobVaultOld(config, location, BLOBS_DIR, BLOBS_EXTENSION, BlobHandleGenerator.IMMUTABLE);
+                    blobVault = new FileSystemBlobVaultOld(environment, config, location, BLOBS_DIR, BLOBS_EXTENSION, BlobHandleGenerator.IMMUTABLE);
                 } else {
-                    blobVault = new FileSystemBlobVaultOld(config, location, BLOBS_DIR, BLOBS_EXTENSION,
+                    blobVault = new FileSystemBlobVaultOld(environment, config, location, BLOBS_DIR, BLOBS_EXTENSION,
                             new PersistentSequenceBlobHandleGenerator(persistentSequenceGetter));
                 }
             }
@@ -887,7 +887,7 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
                                @NotNull final String propertyName,
                                @NotNull final Comparable value) {
         if ((value instanceof ComparableSet && ((ComparableSet) value).isEmpty()) ||
-                (value instanceof Boolean && value.equals(false))) {
+                (value instanceof Boolean && value.equals(Boolean.FALSE))) {
             return deleteProperty(txn, entity, propertyName);
         }
         final PropertyValue propValue = propertyTypes.dataToPropertyValue(value);
@@ -1283,12 +1283,18 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
                         @NotNull final PersistentEntity entity,
                         @NotNull final String blobName,
                         @NotNull final InputStream stream) throws IOException {
-        final ByteArraySizedInputStream copy = stream instanceof ByteArraySizedInputStream ?
-                (ByteArraySizedInputStream) stream : blobVault.cloneStream(stream, true);
-        final long blobHandle = createBlobHandle(txn, entity, blobName, copy, copy.size());
+        var bufferedStream = new BufferedInputStream(stream);
+        var maxEmbeddedBlobSize = config.getMaxInPlaceBlobSize();
+
+        bufferedStream.mark(maxEmbeddedBlobSize + 1);
+
+        var size = (int) bufferedStream.skip(maxEmbeddedBlobSize + 1);
+        bufferedStream.reset();
+
+        final long blobHandle = createBlobHandle(txn, entity, blobName, bufferedStream, size);
+
         if (!isEmptyOrInPlaceBlobHandle(blobHandle)) {
-            setBlobFileLength(txn, blobHandle, copy.size());
-            txn.addBlob(blobHandle, copy);
+            txn.addBlob(blobHandle, bufferedStream);
         }
     }
 
@@ -1303,6 +1309,7 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
         final int size = (int) length;
         final long blobHandle = createBlobHandle(txn, entity, blobName,
                 size > config.getMaxInPlaceBlobSize() ? null : blobVault.cloneFile(file), size);
+
         if (!isEmptyOrInPlaceBlobHandle(blobHandle)) {
             setBlobFileLength(txn, blobHandle, length);
             txn.addBlob(blobHandle, file);
@@ -1332,8 +1339,8 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
     private long createBlobHandle(@NotNull final PersistentStoreTransaction txn,
                                   @NotNull final PersistentEntity entity,
                                   @NotNull final String blobName,
-                                  @Nullable final ByteArraySizedInputStream stream,
-                                  final int size) {
+                                  @Nullable final InputStream stream,
+                                  final int size) throws IOException {
         final EntityId id = entity.getId();
         final long entityLocalId = id.getLocalId();
         final int blobId = getPropertyId(txn, blobName, true);
@@ -1353,9 +1360,11 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
             if (stream == null) {
                 throw new NullPointerException("In-memory blob content is expected");
             }
+
+            var embeddedStream = getBlobVault().cloneStream(stream, true);
             if (!useVersion1Format()) {
                 // check for duplicate
-                final ByteIterable hashEntry = findDuplicate(txn, typeId, stream);
+                final ByteIterable hashEntry = findDuplicate(txn, typeId, embeddedStream);
                 if (hashEntry != null) {
                     blobs.put(envTxn, entityLocalId, blobId,
                             new CompoundByteIterable(new ByteIterable[]{
@@ -1372,7 +1381,7 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
                     new CompoundByteIterable(new ByteIterable[]{
                             blobHandleToEntry(blobHandle),
                             CompressedUnsignedLongByteIterable.getIterable(size),
-                            new ArrayByteIterable(stream.toByteArray(), size)
+                            new ArrayByteIterable(embeddedStream.toByteArray(), size)
                     })
             );
         } else {

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentStoreTransaction.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentStoreTransaction.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentStoreTransaction.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentStoreTransaction.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * https://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,24 +24,20 @@ import jetbrains.exodus.core.dataStructures.FakeObjectCache;
 import jetbrains.exodus.core.dataStructures.NonAdjustableConcurrentObjectCache;
 import jetbrains.exodus.core.dataStructures.ObjectCacheBase;
 import jetbrains.exodus.core.dataStructures.ObjectCacheDecorator;
-import jetbrains.exodus.core.dataStructures.hash.LongHashMap;
-import jetbrains.exodus.core.dataStructures.hash.LongHashSet;
-import jetbrains.exodus.core.dataStructures.hash.LongSet;
-import jetbrains.exodus.core.execution.locks.Semaphore;
+import jetbrains.exodus.core.dataStructures.hash.*;
 import jetbrains.exodus.entitystore.iterate.*;
 import jetbrains.exodus.env.*;
+import jetbrains.exodus.util.ByteArraySizedInputStream;
 import jetbrains.exodus.util.StringBuilderSpinAllocator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
 import java.util.function.BiFunction;
 
 @SuppressWarnings({"rawtypes"})
@@ -78,6 +74,10 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
     private LongHashMap<InputStream> blobStreams;
     @Nullable
     private LongHashMap<File> blobFiles;
+
+    @Nullable
+    private LongHashMap<Path> tmpBlobFiles;
+
     private LongSet deferredBlobsToDelete;
     private QueryCancellingPolicy queryCancellingPolicy;
 
@@ -159,8 +159,9 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
     @Override
     public boolean isIdempotent() {
         return getEnvironmentTransaction().isIdempotent() &&
-            (blobStreams == null || blobStreams.isEmpty()) &&
-            (blobFiles == null || blobFiles.isEmpty());
+                (blobStreams == null || blobStreams.isEmpty()) &&
+                (blobFiles == null || blobFiles.isEmpty()) &&
+                (tmpBlobFiles == null || tmpBlobFiles.isEmpty());
     }
 
     @Override
@@ -236,6 +237,8 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
     @Override
     public void revert() {
         txn.revert();
+        revertCaches();
+
         mutableCache = null;
         mutatedInTxn = new ArrayList<>();
     }
@@ -252,8 +255,9 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
             final int entityTypeId = store.getEntityTypeId(this, entityType, true);
             final long entityLocalId = store.getEntitiesSequence(this, entityTypeId).increment();
             if (store.useVersion1Format()) {
+                //noinspection deprecation
                 store.getEntitiesTable(this, entityTypeId).putRight(
-                    txn, LongBinding.longToCompressedEntry(entityLocalId), ZERO_VERSION_ENTRY);
+                        txn, LongBinding.longToCompressedEntry(entityLocalId), ZERO_VERSION_ENTRY);
             } else {
                 store.getEntitiesBitmapTable(this, entityTypeId).set(txn, entityLocalId, true);
             }
@@ -271,7 +275,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         try {
             final EntityId entityId = entity.getId();
             if (store.useVersion1Format()) {
-                final Store entitiesTable = store.getEntitiesTable(this, entityId.getTypeId());
+                @SuppressWarnings("deprecation") final Store entitiesTable = store.getEntitiesTable(this, entityId.getTypeId());
                 entitiesTable.put(txn, LongBinding.longToCompressedEntry(entityId.getLocalId()), ZERO_VERSION_ENTRY);
             } else {
                 final Bitmap bitmapEntitiesTable = store.getEntitiesBitmapTable(this, entityId.getTypeId());
@@ -300,7 +304,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
     }
 
     // TODO: remove ASAP
-    private static final int traceGetAllForEntityType = Integer.getInteger("jetbrains.exodus.entitystore.traceGetAllForEntityType", -1);
+    private static final int traceGetAllForEntityType = Integer.getInteger("jetbrains.exodus.entitystore.traceGetAllForEntityType", -1).intValue();
 
     @Override
     @NotNull
@@ -330,13 +334,13 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
                                @NotNull final Comparable value) {
         if (value instanceof Boolean) {
             final EntityIterableBase withProp = findWithProp(entityType, propertyName);
-            if ((Boolean) value) {
+            if (((Boolean) value).booleanValue()) {
                 return withProp;
             }
             return getAll(entityType).minus(withProp);
         }
         return getPropertyIterable(entityType, propertyName, (entityTypeId, propertyId) ->
-            new PropertyValueIterable(this, entityTypeId, propertyId, value));
+                new PropertyValueIterable(this, entityTypeId.intValue(), propertyId.intValue(), value));
     }
 
     @Override
@@ -344,8 +348,8 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
     public EntityIterable find(@NotNull final String entityType, @NotNull final String propertyName,
                                @NotNull final Comparable minValue, @NotNull final Comparable maxValue) {
         if (minValue instanceof Boolean) {
-            final boolean min = (Boolean) minValue;
-            final boolean max = (Boolean) maxValue;
+            final boolean min = ((Boolean) minValue).booleanValue();
+            final boolean max = ((Boolean) maxValue).booleanValue();
             if (min == max) {
                 if (min) {
                     return findWithProp(entityType, propertyName);
@@ -358,7 +362,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
             return EntityIterableBase.EMPTY;
         }
         return getPropertyIterable(entityType, propertyName, (entityTypeId, propertyId) ->
-            new PropertyRangeIterable(this, entityTypeId, propertyId, minValue, maxValue));
+                new PropertyRangeIterable(this, entityTypeId.intValue(), propertyId.intValue(), minValue, maxValue));
     }
 
     @Override
@@ -368,7 +372,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
             return findWithPropSortedByValue(entityType, propertyName);
         }
         return getPropertyIterable(entityType, propertyName, (entityTypeId, propertyId) ->
-            new PropertyContainsValueEntityIterable(this, entityTypeId, propertyId, value, ignoreCase));
+                new PropertyContainsValueEntityIterable(this, entityTypeId.intValue(), propertyId.intValue(), value, ignoreCase));
     }
 
     @Override
@@ -385,12 +389,12 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
     @Override
     public EntityIterableBase findWithProp(@NotNull final String entityType, @NotNull final String propertyName) {
         return getPropertyIterable(entityType, propertyName, (entityTypeId, propertyId) ->
-            new EntitiesWithPropertyIterable(this, entityTypeId, propertyId));
+                new EntitiesWithPropertyIterable(this, entityTypeId.intValue(), propertyId.intValue()));
     }
 
     public EntityIterableBase findWithPropSortedByValue(@NotNull final String entityType, @NotNull final String propertyName) {
         return getPropertyIterable(entityType, propertyName, (entityTypeId, propertyId) ->
-            new PropertiesIterable(this, entityTypeId, propertyId));
+                new PropertiesIterable(this, entityTypeId.intValue(), propertyId.intValue()));
     }
 
     @Override
@@ -409,7 +413,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
     @Override
     public EntityIterable findWithBlob(@NotNull final String entityType, @NotNull final String blobName) {
         return getPropertyIterable(entityType, blobName, (entityTypeId, blobId) ->
-            new EntitiesWithBlobIterable(this, entityTypeId, blobId));
+                new EntitiesWithBlobIterable(this, entityTypeId.intValue(), blobId.intValue()));
     }
 
     @Override
@@ -521,7 +525,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
             return rightOrder;
         }
         return new SortIterable(this, findWithPropSortedByValue(
-            entityType, propertyName), (EntityIterableBase) rightOrder, entityTypeId, propertyId, ascending);
+                entityType, propertyName), (EntityIterableBase) rightOrder, entityTypeId, propertyId, ascending);
     }
 
     @Override
@@ -532,7 +536,8 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
                                     @NotNull final String linkName,
                                     @NotNull final EntityIterable rightOrder) {
         final EntityIterable result = new SortIndirectIterable(this, store, entityType,
-            ((EntityIterableBase) sortedLinks).getSource(), linkName, (EntityIterableBase) rightOrder, null, null);
+                ((EntityIterableBase) sortedLinks).getSource(), linkName, (EntityIterableBase) rightOrder,
+                null, null);
         return isMultiple ? result.distinct() : result;
     }
 
@@ -546,7 +551,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
                                     @NotNull final String oppositeEntityType,
                                     @NotNull final String oppositeLinkName) {
         final EntityIterable result = new SortIndirectIterable(this, store, entityType,
-            ((EntityIterableBase) sortedLinks).getSource(), linkName, (EntityIterableBase) rightOrder, oppositeEntityType, oppositeLinkName);
+                ((EntityIterableBase) sortedLinks).getSource(), linkName, (EntityIterableBase) rightOrder, oppositeEntityType, oppositeLinkName);
         return isMultiple ? result.distinct() : result;
     }
 
@@ -580,7 +585,8 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
                 filtered.add(it);
             }
         }
-        return filtered == null ? EntityIterableBase.EMPTY : new MergeSortedIterableWithValueGetter(this, filtered, valueGetter, comparator);
+        return filtered == null ? EntityIterableBase.EMPTY : new MergeSortedIterableWithValueGetter(this,
+                filtered, valueGetter, comparator);
     }
 
     @Override
@@ -766,7 +772,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         final PropertyId propId = new PropertyId(id, propertyId);
         propsCache.remove(propId);
         new PropertyChangedHandleCheckerImpl(this, id, propertyId,
-            oldValue, newValue, mutableCache(), mutatedInTxn).updateCache();
+                oldValue, newValue, mutableCache(), mutatedInTxn).updateCache();
     }
 
     void linkAdded(@NotNull final PersistentEntityId sourceId,
@@ -785,17 +791,23 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         new LinkDeletedHandleChecker(this, sourceId, targetId, linkId, mutableCache(), mutatedInTxn).updateCache();
     }
 
-    void addBlob(final long blobHandle, @NotNull final InputStream stream) {
+    void addBlob(final long blobHandle, @NotNull InputStream stream) {
         LongHashMap<InputStream> blobStreams = this.blobStreams;
+
         if (blobStreams == null) {
             blobStreams = new LongHashMap<>();
             this.blobStreams = blobStreams;
         }
-        if (!stream.markSupported()) {
-            throw new EntityStoreException("Blob input stream should support the mark and reset methods");
+
+        InputStream bufferedInputStream;
+        if (stream instanceof ByteArraySizedInputStream || stream instanceof BufferedInputStream) {
+            bufferedInputStream = stream;
+        } else {
+            bufferedInputStream = new BufferedInputStream(stream);
         }
-        stream.mark(Integer.MAX_VALUE);
-        blobStreams.put(blobHandle, stream);
+
+        bufferedInputStream.mark(Integer.MAX_VALUE);
+        blobStreams.put(blobHandle, bufferedInputStream);
     }
 
     void addBlob(final long blobHandle, @NotNull final File file) {
@@ -809,6 +821,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
 
     void deleteBlob(final long blobHandle) {
         if (blobStreams != null) {
+            //noinspection resource
             blobStreams.remove(blobHandle);
         }
         if (blobFiles != null) {
@@ -818,13 +831,28 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
 
     long getBlobSize(final long blobHandle) throws IOException {
         final LongHashMap<InputStream> blobStreams = this.blobStreams;
+
         if (blobStreams != null) {
             final InputStream stream = blobStreams.get(blobHandle);
             if (stream != null) {
-                stream.reset();
-                return stream.skip(Long.MAX_VALUE); // warning, this may return inaccurate results
+                if (stream instanceof ByteArraySizedInputStream) {
+                    return ((ByteArraySizedInputStream) stream).size();
+                }
+
+                try {
+                    assert stream.markSupported();
+
+                    stream.reset();
+                    stream.mark(Integer.MAX_VALUE);
+
+                    return stream.skip(Long.MAX_VALUE); // warning, this may return inaccurate results
+                } finally {
+                    stream.reset();
+                    stream.mark(Integer.MAX_VALUE);
+                }
             }
         }
+
         final LongHashMap<File> blobFiles = this.blobFiles;
         if (blobFiles != null) {
             final File file = blobFiles.get(blobHandle);
@@ -832,26 +860,30 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
                 return file.length();
             }
         }
+
         return -1;
     }
 
     @Nullable
     InputStream getBlobStream(final long blobHandle) throws IOException {
         final LongHashMap<InputStream> blobStreams = this.blobStreams;
+
         if (blobStreams != null) {
             final InputStream stream = blobStreams.get(blobHandle);
             if (stream != null) {
                 stream.reset();
-                return stream;
+                return new InputStreamCloseGuard(stream);
             }
         }
+
         final LongHashMap<File> blobFiles = this.blobFiles;
         if (blobFiles != null) {
             final File file = blobFiles.get(blobHandle);
             if (file != null) {
-                return store.getBlobVault().cloneFile(file);
+                return store.getBlobVault().getFileStream(file);
             }
         }
+
         return null;
     }
 
@@ -881,9 +913,21 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         localCache = (EntityIterableCacheAdapter) store.getEntityIterableCache().getCacheAdapter();
         mutableCache = null;
         mutatedInTxn = null;
-        blobStreams = null;
+
+        if (blobStreams != null) {
+            for (var stream : blobStreams.values()) {
+                try {
+                    stream.close();
+                } catch (IOException e) {
+                    logger.error("Error during reverting of caches.", e);
+                }
+            }
+            blobStreams = null;
+        }
+
         blobFiles = null;
         deferredBlobsToDelete = null;
+        tmpBlobFiles = null;
     }
 
     // exposed only for tests
@@ -893,12 +937,61 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         final BlobVault blobVault = store.getBlobVault();
         if (blobVault.requiresTxn()) {
             try {
-                blobVault.flushBlobs(blobStreams, blobFiles, deferredBlobsToDelete, txn);
+                blobVault.flushBlobs(blobStreams, blobFiles, null, deferredBlobsToDelete, txn);
             } catch (Exception e) {
                 // out of disk space not expected there
                 throw ExodusException.toEntityStoreException(e);
             }
+        } else if (blobStreams != null && blobVault instanceof DiskBasedBlobVault) {
+            ((TransactionBase) txn).setBeforeTransactionFlushAction(() -> {
+                var diskBasedBlobVault = (DiskBasedBlobVault) blobVault;
+                tmpBlobFiles = new LongHashMap<>();
+
+                try {
+                    for (Map.Entry<Long, InputStream> entry : blobStreams.entrySet()) {
+                        var handle = entry.getKey();
+                        var stream = entry.getValue();
+
+                        var blobHandle = handle.longValue();
+
+                        var tmpFile = diskBasedBlobVault.copyToTemporaryStore(blobHandle, stream);
+                        tmpBlobFiles.put(blobHandle, tmpFile);
+
+                        store.setBlobFileLength(this, blobHandle, Files.size(tmpFile));
+                    }
+                } catch (Exception e) {
+                    for (var blob : tmpBlobFiles.values()) {
+                        try {
+                            Files.deleteIfExists(blob);
+                        } catch (final IOException ex) {
+                            logger.error("Error during deletion of blob " + blob + " during clean up after error.",
+                                    ex);
+                        }
+                    }
+
+                    try {
+                        diskBasedBlobVault.generateDirForTmpBlobs(store.getEnvironment());
+                    } catch (final IOException ex) {
+                        logger.error("Error during re-generation of temporary directory during clean up process.",
+                                ex);
+                    }
+
+                    for (var stream : blobStreams.values()) {
+                        try {
+                            stream.close();
+                        } catch (IOException ex) {
+                            logger.error("Error during closing of blob stream during clean up process.",
+                                    ex);
+                        }
+                    }
+
+                    throw new ExodusException("Error during creation of temporary file for blob", e);
+                } finally {
+                    blobStreams = null;
+                }
+            });
         }
+
         txn.setCommitHook(() -> {
             log.flushed();
             final EntityIterableCacheAdapterMutable cache = PersistentStoreTransaction.this.mutableCache;
@@ -935,10 +1028,12 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
     private void flushNonTransactionalBlobs() {
         final BlobVault blobVault = store.getBlobVault();
         if (!blobVault.requiresTxn()) {
-            if (blobStreams != null || blobFiles != null || deferredBlobsToDelete != null) {
+            assert blobStreams == null;
+
+            if (tmpBlobFiles != null || blobFiles != null || deferredBlobsToDelete != null) {
                 ((EnvironmentImpl) txn.getEnvironment()).flushAndSync();
                 try {
-                    blobVault.flushBlobs(blobStreams, blobFiles, deferredBlobsToDelete, txn);
+                    blobVault.flushBlobs(null, blobFiles, tmpBlobFiles, deferredBlobsToDelete, txn);
                 } catch (Exception e) {
                     handleOutOfDiskSpace(e);
                     throw ExodusException.toEntityStoreException(e);
@@ -979,7 +1074,8 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         if (propertyId < 0) {
             return EntityIterableBase.EMPTY;
         }
-        return instantiator.apply(entityTypeId, propertyId);
+
+        return instantiator.apply(Integer.valueOf(entityTypeId), Integer.valueOf(propertyId));
     }
 
     @SuppressWarnings("unchecked")
@@ -1007,7 +1103,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
                     handlePart = "";
                 }
                 logger.error("Iterable doesn't match expected class " + handleType.getName()
-                    + ", handle = " + handle + ", found = " + instance.getClass().getName() + handlePart);
+                        + ", handle = " + handle + ", found = " + instance.getClass().getName() + handlePart);
             }
         }
         return null;
@@ -1015,8 +1111,8 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
 
     private <V> ObjectCacheBase<PropertyId, V> createObjectCache(final int size) {
         return size == 0 ?
-            new FakeObjectCache<>() :
-            new TransactionObjectCache<>(size);
+                new FakeObjectCache<>() :
+                new TransactionObjectCache<>(size);
     }
 
     abstract static class HandleCheckerAdapter implements HandleChecker {
@@ -1163,7 +1259,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         @Override
         public boolean checkHandle(@NotNull final EntityIterableHandle handle) {
             return handle.isMatchedEntityDeleted(id)
-                && !handle.onEntityDeleted(this);
+                    && !handle.onEntityDeleted(this);
         }
     }
 
@@ -1179,7 +1275,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         @Override
         public boolean checkHandle(@NotNull final EntityIterableHandle handle) {
             return handle.isMatchedEntityAdded(id)
-                && !handle.onEntityAdded(this);
+                    && !handle.onEntityAdded(this);
         }
     }
 
@@ -1249,7 +1345,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         @Override
         public boolean checkHandle(@NotNull EntityIterableHandle handle) {
             return handle.isMatchedLinkAdded(sourceId, targetId, linkId)
-                && !handle.onLinkAdded(this);
+                    && !handle.onLinkAdded(this);
         }
     }
 
@@ -1265,7 +1361,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         @Override
         public boolean checkHandle(@NotNull EntityIterableHandle handle) {
             return handle.isMatchedLinkDeleted(sourceId, targetId, linkId)
-                && !handle.onLinkDeleted(this);
+                    && !handle.onLinkDeleted(this);
         }
     }
 
@@ -1323,7 +1419,7 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         @Override
         public boolean checkHandle(@NotNull EntityIterableHandle handle) {
             return handle.isMatchedPropertyChanged(id, propertyId, oldValue, newValue)
-                && !handle.onPropertyChanged(this);
+                    && !handle.onPropertyChanged(this);
         }
 
         @Override
@@ -1336,8 +1432,8 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
             if (propertyId != that.propertyId) return false;
             if (!id.equals(that.id)) return false;
             //noinspection SimplifiableIfStatement
-            if (newValue != null ? !newValue.equals(that.newValue) : that.newValue != null) return false;
-            return !(oldValue != null ? !oldValue.equals(that.oldValue) : that.oldValue != null);
+            if (!Objects.equals(newValue, that.newValue)) return false;
+            return Objects.equals(oldValue, that.oldValue);
         }
 
         @Override
@@ -1359,6 +1455,17 @@ public class PersistentStoreTransaction implements StoreTransaction, TxnGetterSt
         @Override
         protected ObjectCacheBase<PropertyId, V> createdDecorated() {
             return new NonAdjustableConcurrentObjectCache<>(size(), LOCAL_CACHE_GENERATIONS);
+        }
+    }
+
+    private static final class InputStreamCloseGuard extends FilterInputStream {
+        private InputStreamCloseGuard(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public void close() {
+            //do nothing
         }
     }
 }

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/VFSBlobVault.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/VFSBlobVault.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2010 - 2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/VFSBlobVault.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/VFSBlobVault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2010 - 2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.util.Map;
 
 public class VFSBlobVault extends BlobVault {
@@ -46,10 +47,6 @@ public class VFSBlobVault extends BlobVault {
 
     @NotNull
     private final VirtualFileSystem fs;
-
-    public VFSBlobVault(@NotNull final PersistentEntityStoreConfig config, @NotNull final Environment env) {
-        this(config, new VirtualFileSystem(env, BLOB_VAULT_VFS_CONFIG));
-    }
 
     public VFSBlobVault(@NotNull final PersistentEntityStoreConfig config, @NotNull final VirtualFileSystem fs) {
         super(config);
@@ -122,20 +119,20 @@ public class VFSBlobVault extends BlobVault {
     @Override
     public void flushBlobs(@Nullable final LongHashMap<InputStream> blobStreams,
                            @Nullable final LongHashMap<File> blobFiles,
-                           @Nullable final LongSet deferredBlobsToDelete,
+                           @Nullable LongHashMap<Path> tmpBlobs, @Nullable final LongSet deferredBlobsToDelete,
                            @NotNull final Transaction txn) throws Exception {
         if (blobStreams != null) {
             blobStreams.forEachEntry((ObjectProcedureThrows<Map.Entry<Long, InputStream>, Exception>) object -> {
                 final InputStream stream = object.getValue();
                 stream.reset();
-                setContent(object.getKey(), stream, txn);
+                setContent(object.getKey().longValue(), stream, txn);
                 return true;
             });
         }
         // if there were blob files then move them
         if (blobFiles != null) {
             blobFiles.forEachEntry((ObjectProcedureThrows<Map.Entry<Long, File>, Exception>) object -> {
-                setContent(object.getKey(), object.getValue(), txn);
+                setContent(object.getKey().longValue(), object.getValue(), txn);
                 return true;
             });
         }
@@ -174,7 +171,8 @@ public class VFSBlobVault extends BlobVault {
     }
 
     public void refactorFromFS(@NotNull final PersistentEntityStoreImpl store) throws IOException {
-        final BlobVault sourceVault = new FileSystemBlobVaultOld(store.getConfig(), store.getLocation(),
+        final BlobVault sourceVault = new FileSystemBlobVaultOld(store.getEnvironment(),
+                store.getConfig(), store.getLocation(),
                 "blobs", ".blob", BlobHandleGenerator.IMMUTABLE);
 
         final LongSet allBlobs = store.computeInReadonlyTransaction(txn -> loadAllBlobs(store, (PersistentStoreTransaction) txn));

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/DummyBlobVault.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/DummyBlobVault.kt
@@ -20,6 +20,7 @@ import jetbrains.exodus.core.dataStructures.hash.LongSet
 import jetbrains.exodus.env.Transaction
 import java.io.File
 import java.io.InputStream
+import java.nio.file.Path
 
 /**
  * A blob vault that stores no blobs. Is intended to be used with in-memory databases for which all blobs are stored
@@ -43,10 +44,12 @@ class DummyBlobVault(config: PersistentEntityStoreConfig) : BlobVault(config) {
 
     override fun requiresTxn() = false
 
-    override fun flushBlobs(blobStreams: LongHashMap<InputStream>?,
-                            blobFiles: LongHashMap<File>?,
-                            deferredBlobsToDelete:
-                            LongSet?, txn: Transaction) = throw NotImplementedError()
+    override fun flushBlobs(
+        blobStreams: LongHashMap<InputStream>?,
+        blobFiles: LongHashMap<File>?,
+        tmpBlobs: LongHashMap<Path>?, deferredBlobsToDelete:
+        LongSet?, txn: Transaction
+    ) = throw NotImplementedError()
 
     override fun size() = 0L
 

--- a/environment/src/main/java/jetbrains/exodus/env/EnvironmentImpl.java
+++ b/environment/src/main/java/jetbrains/exodus/env/EnvironmentImpl.java
@@ -775,6 +775,9 @@ public class EnvironmentImpl implements Environment {
                 // meta lock not needed 'cause write can only occur in another commit lock
                 return false;
             }
+
+            txn.executeBeforeTransactionFlushAction();
+
             if (wasUpSaved) {
                 up.setDirty(false);
             }

--- a/environment/src/main/java/jetbrains/exodus/env/TransactionBase.java
+++ b/environment/src/main/java/jetbrains/exodus/env/TransactionBase.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/environment/src/main/java/jetbrains/exodus/env/TransactionBase.java
+++ b/environment/src/main/java/jetbrains/exodus/env/TransactionBase.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * https://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,6 +52,9 @@ public abstract class TransactionBase implements Transaction {
     @Nullable
     private StackTrace traceFinish;
     private boolean disableStoreGetCache;
+
+    @Nullable
+    private Runnable beforeTransactionFlushAction;
 
     public TransactionBase(@NotNull final EnvironmentImpl env, final boolean isExclusive) {
         this.env = env;
@@ -223,6 +226,16 @@ public abstract class TransactionBase implements Transaction {
     protected void clearImmutableTrees() {
         synchronized (immutableTrees) {
             immutableTrees.clear();
+        }
+    }
+
+    public void setBeforeTransactionFlushAction(@NotNull Runnable exec) {
+        this.beforeTransactionFlushAction = exec;
+    }
+
+    void executeBeforeTransactionFlushAction() {
+        if (beforeTransactionFlushAction != null) {
+            beforeTransactionFlushAction.run();
         }
     }
 

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/BlobVault.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/BlobVault.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/BlobVault.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/BlobVault.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * https://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
@@ -99,7 +100,7 @@ public abstract class BlobVault implements BlobHandleGenerator, Backupable {
         }
         files.add(file);
         final StringBuilder dir = new StringBuilder();
-        for (ListIterator iterator = files.listIterator(files.size()); iterator.hasPrevious(); ) {
+        for (ListIterator<String> iterator = files.listIterator(files.size()); iterator.hasPrevious(); ) {
             dir.append('/');
             dir.append(iterator.previous());
         }
@@ -145,10 +146,11 @@ public abstract class BlobVault implements BlobHandleGenerator, Backupable {
     public abstract boolean requiresTxn();
 
     /**
-     * Method called by {@linkplain PersistentEntityStore} to flush blobs identified by blobs. Two maps represent two
+     * Method called by {@linkplain PersistentEntityStore} to flush blobs identified by blobs. Three maps represent three
      * ways of dealing with blob content: using streams and {@code java.io.File} instances. They naturally follow from
      * the {@linkplain Entity} API, having two methods to set blob: {@linkplain Entity#setBlob(String, InputStream)}
-     * and {@linkplain Entity#setBlob(String, File)}.
+     * and {@linkplain Entity#setBlob(String, File)}. The last map is used to keep copy  of streams into temporary vault
+     * storage before commit and then moving them into permanent vault store after commit to ensure durability of commit.
      *
      * <p>The set {@code deferredBlobsToDelete} contains blob handles of blobs that should be deleted after the
      * transaction is finished. In most cases, these blobs cannot be deleted immediately without violating isolation
@@ -160,6 +162,8 @@ public abstract class BlobVault implements BlobHandleGenerator, Backupable {
      *
      * @param blobStreams           map of blob handles to {@linkplain InputStream} instances
      * @param blobFiles             map of blob handles to {@linkplain File} instances
+     * @param tmpBlobs              map of blob which were temporary stored inside of vault using
+     *                              {@link DiskBasedBlobVault#copyToTemporaryStore(long, InputStream)}
      * @param deferredBlobsToDelete set of blob handles of blobs that should be deleted after the transaction is finished
      * @param txn                   {@linkplain Transaction} instance
      * @throws Exception something went wrong
@@ -169,7 +173,7 @@ public abstract class BlobVault implements BlobHandleGenerator, Backupable {
      */
     public abstract void flushBlobs(@Nullable final LongHashMap<InputStream> blobStreams,
                                     @Nullable final LongHashMap<File> blobFiles,
-                                    @Nullable final LongSet deferredBlobsToDelete,
+                                    @Nullable LongHashMap<Path> tmpBlobs, @Nullable final LongSet deferredBlobsToDelete,
                                     @NotNull final Transaction txn) throws Exception;
 
     /**
@@ -242,6 +246,10 @@ public abstract class BlobVault implements BlobHandleGenerator, Backupable {
                                                        final boolean closeSource) throws IOException {
         final ByteArrayOutputStream memCopy = copyStream(source, closeSource);
         return new ByteArraySizedInputStream(memCopy.toByteArray(), 0, memCopy.size());
+    }
+
+    public final BufferedInputStream getFileStream(@NotNull final File file) throws IOException {
+        return new BufferedInputStream(new FileInputStream(file));
     }
 
     public final ByteArraySizedInputStream cloneFile(@NotNull final File file) throws IOException {

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/DiskBasedBlobVault.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/DiskBasedBlobVault.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/DiskBasedBlobVault.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/DiskBasedBlobVault.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * https://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,12 +15,15 @@
  */
 package jetbrains.exodus.entitystore;
 
+import jetbrains.exodus.env.Environment;
 import jetbrains.exodus.env.Transaction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 
 public interface DiskBasedBlobVault {
 
@@ -38,4 +41,8 @@ public interface DiskBasedBlobVault {
     long size();
 
     void close();
+
+    @NotNull Path copyToTemporaryStore(long handle, final @NotNull InputStream stream) throws IOException;
+
+    void generateDirForTmpBlobs(Environment environment) throws IOException;
 }

--- a/utils/src/main/java/jetbrains/exodus/util/UTFUtil.java
+++ b/utils/src/main/java/jetbrains/exodus/util/UTFUtil.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2010 - 2023 JetBrains s.r.o.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
1. Callback which allows executing version post-validation actions before data flush was added.
2. BufferedInputStreams are used instead of ByteArray streams to fall back to the stored position during the processing of stream inside EntityStore. Which should decrease the risk of OOM.
3. All streams are stored in the temporary directory before transaction flush (after validation of the transaction version) and then moved to the BlobVault location after a successful commit. That is done gracefully handling situations when streams generate errors while storing the data.
4. Passed-in streams are automatically closed during commit/flush and abort/revert of transaction.
