### PR TITLE
Issue #XD-904 fixed

### DIFF
--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVaultOld.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/FileSystemBlobVaultOld.java
@@ -176,9 +176,14 @@ public class FileSystemBlobVaultOld extends BlobVault implements DiskBasedBlobVa
 
     @Override
     @Nullable
-    public InputStream getContent(final long blobHandle, @NotNull final Transaction txn) {
+    public InputStream getContent(final long blobHandle, @NotNull final Transaction txn, @Nullable Long expectedLength) {
         try {
-            return new FileInputStream(getBlobLocation(blobHandle));
+            File location = getBlobLocation(blobHandle);
+            if (expectedLength != null && location.length() != expectedLength.longValue()) {
+                return null;
+            }
+
+            return new FileInputStream(location);
         } catch (FileNotFoundException e) {
             return null;
         }

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
@@ -1052,7 +1052,41 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
         if (result != null) {
             return result;
         }
-        result = blobVault.getContent(blobHandle, txn.getEnvironmentTransaction());
+
+        Transaction envTxn = txn.getEnvironmentTransaction();
+        Long blobLength = getBlobFileLength(blobHandle, envTxn);
+
+        result = blobVault.getContent(blobHandle, envTxn, blobLength);
+
+        if (result == null) {
+            int counter = 0;
+
+            final int sleepInterval = 50;
+            final int counterMaxValue = config.getBlobMaxReadWaitingInterval() * 1000 / sleepInterval;
+
+            while (true) {
+                try {
+                    Thread.sleep(sleepInterval);
+                } catch (InterruptedException e) {
+                    throw new ExodusException("Store : " + getName() +
+                            " . Reading of blob content was interrupted.", e);
+                }
+                counter++;
+
+                result = blobVault.getContent(blobHandle, envTxn,
+                        blobLength);
+
+                if (result != null) {
+                    break;
+                }
+
+                if (counter >= counterMaxValue) {
+                    throw new ExodusException("Store : " + getName() + " data is broken. " +
+                            "Can not read blob with handle " + blobHandle);
+                }
+            }
+        }
+
         if (result == null && !readerWriterProvider.isReadonly()) {
             loggerWarn("Blob not found: " + blobVault.getBlobLocation(blobHandle), new FileNotFoundException());
         }
@@ -1082,7 +1116,41 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
             try {
                 final InputStream stream = blobStream.getSecond();
                 if (stream == null) {
-                    return blobVault.getStringContent(blobHandle, txn.getEnvironmentTransaction());
+                    Transaction envTxn = txn.getEnvironmentTransaction();
+                    Long blobLength = getBlobFileLength(blobHandle, envTxn);
+
+                    String blobString = blobVault.getStringContent(blobHandle, envTxn,
+                            blobLength);
+
+                    if (blobString != null) {
+                        return blobString;
+                    }
+
+                    int counter = 0;
+                    final int sleepInterval = 50;
+                    final int counterMaxValue = config.getBlobMaxReadWaitingInterval() * 1000 / sleepInterval;
+
+                    while (true) {
+                        try {
+                            Thread.sleep(sleepInterval);
+                        } catch (InterruptedException e) {
+                            throw new ExodusException("Store : " + getName() +
+                                    " . Reading of blob content was interrupted.", e);
+                        }
+                        counter++;
+
+                        blobString = blobVault.getStringContent(blobHandle, envTxn,
+                                blobLength);
+
+                        if (blobString != null) {
+                            return blobString;
+                        }
+
+                        if (counter >= counterMaxValue) {
+                            throw new ExodusException("Store : " + getName() + " data is broken. " +
+                                    "Can not read blob with handle " + blobHandle);
+                        }
+                    }
                 }
                 result = UTFUtil.readUTF(stream);
             } catch (UTFDataFormatException e) {

--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/VFSBlobVault.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/VFSBlobVault.java
@@ -89,8 +89,16 @@ public class VFSBlobVault extends BlobVault {
     }
 
     @Override
-    @NotNull
-    public InputStream getContent(long blobHandle, @NotNull final Transaction txn) {
+    @Nullable
+    public InputStream getContent(long blobHandle, @NotNull final Transaction txn, @Nullable Long expectedLength) {
+        if (expectedLength != null) {
+            long actualLength = fs.getFileLength(txn, blobHandle);
+
+            if (actualLength != expectedLength.longValue()) {
+                return null;
+            }
+        }
+
         return fs.readFile(txn, blobHandle);
     }
 
@@ -184,7 +192,7 @@ public class VFSBlobVault extends BlobVault {
                 if (i++ % 100 == 0) {
                     txn.flush();
                 }
-                final InputStream content = sourceVault.getContent(blobId, txn);
+                final InputStream content = sourceVault.getContent(blobId, txn, null);
                 if (content != null) {
                     importBlob(txn, blobId, content);
                 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/crypto/EncryptedBlobVault.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/crypto/EncryptedBlobVault.kt
@@ -45,8 +45,12 @@ class EncryptedBlobVault(
         return decorated.getBlob(blobHandle)
     }
 
-    override fun getContent(blobHandle: Long, txn: Transaction): InputStream? {
-        return decorated.getContent(blobHandle, txn)?.run {
+    override fun getContent(
+        blobHandle: Long,
+        txn: Transaction,
+        expectedLength: Long?
+    ): InputStream? {
+        return decorated.getContent(blobHandle, txn, expectedLength)?.run {
             StreamCipherInputStream(this) {
                 newCipher(blobHandle)
             }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/DummyBlobVault.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/DummyBlobVault.kt
@@ -34,7 +34,11 @@ class DummyBlobVault(config: PersistentEntityStoreConfig) : BlobVault(config) {
 
     override fun getBackupStrategy() = throw NotImplementedError()
 
-    override fun getContent(blobHandle: Long, txn: Transaction) = throw NotImplementedError()
+    override fun getContent(
+        blobHandle: Long,
+        txn: Transaction,
+        expectedLength: Long?
+    ) = throw NotImplementedError()
 
     override fun getSize(blobHandle: Long, txn: Transaction) = throw NotImplementedError()
 

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/EntityBlobTests.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/EntityBlobTests.kt
@@ -233,7 +233,7 @@ class EntityBlobTests : EntityStoreTestBase() {
         }
         store.executeInReadonlyTransaction { txn ->
             txn as PersistentStoreTransaction
-            val content = store.blobVault.getContent(0, txn.environmentTransaction)
+            val content = store.blobVault.getContent(0, txn.environmentTransaction, null)
             assertNotNull(content)
             try {
                 content?.close()
@@ -244,7 +244,8 @@ class EntityBlobTests : EntityStoreTestBase() {
         store.clear()
         store.executeInReadonlyTransaction { txn ->
             assertNull(store.blobVault
-                .getContent(0, (txn as PersistentStoreTransaction).environmentTransaction))
+                .getContent(0, (txn as PersistentStoreTransaction).environmentTransaction,
+                    null))
         }
     }
 

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/DiskBasedBlobVault.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/DiskBasedBlobVault.java
@@ -35,7 +35,8 @@ public interface DiskBasedBlobVault {
 
     boolean delete(long blobHandle);
 
-    @Nullable InputStream getContent(long blobHandle, @NotNull Transaction txn);
+    @Nullable InputStream getContent(long blobHandle, @NotNull Transaction txn,
+                                     @Nullable Long expectedContentLength);
 
     long size();
 


### PR DESCRIPTION
When using the file system for storing blobs, the content is written after committing metadata in the Xodus Environment. That implies a delay between transaction acknowledgement and the actual writing of data which can cause a situation when blob content can be incorrectly read in another thread. Blob content is checked before returning to the user to avoid such situations. If the content is incomplete, the thread will wait a specified time in seconds until the transaction wholly writes blob content. Otherwise, an exception will be thrown.

(cherry-picked from commit 343b730839e50975c062185d47125bed6b73d0b8)
