### PR TITLE
Add unmonitored transactions

### DIFF
--- a/environment/src/main/java/jetbrains/exodus/env/EnvironmentImpl.java
+++ b/environment/src/main/java/jetbrains/exodus/env/EnvironmentImpl.java
@@ -373,6 +373,17 @@ public class EnvironmentImpl implements Environment {
     }
 
     @NotNull
+    public TransactionBase beginReadOnlyUnmonitoredTransaction(){
+        checkIsOperative();
+        return new ReadonlyTransaction(this, false, null) {
+            @Override
+            boolean isIgnoreInStuckTransactionMonitor() {
+                return true;
+            }
+        };
+    }
+
+    @NotNull
     public ReadWriteTransaction beginGCTransaction() {
         if (isReadOnly()) {
             throw new ReadonlyTransactionException("Can't start GC transaction on read-only Environment");

--- a/environment/src/main/java/jetbrains/exodus/env/TransactionBase.java
+++ b/environment/src/main/java/jetbrains/exodus/env/TransactionBase.java
@@ -215,6 +215,10 @@ public abstract class TransactionBase implements Transaction {
         return false;
     }
 
+    boolean isIgnoreInStuckTransactionMonitor(){
+        return false;
+    }
+
     @Nullable
     TreeMetaInfo getTreeMetaInfo(@NotNull final String name) {
         checkIsFinished();

--- a/environment/src/main/kotlin/jetbrains/exodus/env/StuckTransactionMonitor.kt
+++ b/environment/src/main/kotlin/jetbrains/exodus/env/StuckTransactionMonitor.kt
@@ -72,7 +72,7 @@ internal class StuckTransactionMonitor(env: EnvironmentImpl) : Job() {
             val timeBound = System.currentTimeMillis() - this
             env?.forEachActiveTransaction {
                 val txn = it as TransactionBase
-                if (!txn.isGCTransaction && txn.startTime < timeBound) {
+                if (!txn.isGCTransaction && !txn.isIgnoreInStuckTransactionMonitor  && txn.startTime < timeBound) {
                     callback(it)
                 }
             }

--- a/environment/src/main/kotlin/jetbrains/exodus/env/management/BackupController.kt
+++ b/environment/src/main/kotlin/jetbrains/exodus/env/management/BackupController.kt
@@ -34,7 +34,7 @@ class BackupController(private val env: EnvironmentImpl) : MBeanBase(getObjectNa
                 throw IllegalStateException("Backup is already in progress")
             }
 
-            backupTransaction = env.beginReadonlyTransaction()
+            backupTransaction = env.beginReadOnlyUnmonitoredTransaction()
             return env.prepareForBackup()
         } finally {
             backupTransactionLock.unlock()


### PR DESCRIPTION
Internal transaction of backupController is no more monitored by stuck transaction monitor and not cancelled after a timeout.

### What does this PR do?

Add check in stuck transaction monitor and add property to BaseTransaction.

### Motivation

Described transaction can be cancelled by StuckTransaction monitor and this will cause state that cannot be fixed in runtime.

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
