### PR TITLE
Optimize BitmapIterator by removing Long boxing

### DIFF
--- a/benchmarks/src/jmh/java/jetbrains/exodus/benchmark/env/JMHBitmapIteratorBenchmark.java
+++ b/benchmarks/src/jmh/java/jetbrains/exodus/benchmark/env/JMHBitmapIteratorBenchmark.java
@@ -1,0 +1,78 @@
+package jetbrains.exodus.benchmark.env;
+
+import jetbrains.exodus.env.*;
+import jetbrains.exodus.log.Log;
+import org.jetbrains.annotations.NotNull;
+import org.junit.rules.TemporaryFolder;
+import org.openjdk.jmh.annotations.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+
+@State(Scope.Thread)
+public class JMHBitmapIteratorBenchmark {
+
+    public TemporaryFolder temporaryFolder;
+    public Environment env;
+    public BitmapImpl store;
+
+    @SuppressWarnings("deprecation") // Log.invalidateSharedCache is test-only
+    @Setup(Level.Iteration)
+    public void setup() throws IOException {
+        Log.invalidateSharedCache();
+        temporaryFolder = new TemporaryFolder();
+        temporaryFolder.create();
+        final File testsDirectory = temporaryFolder.newFolder("data");
+        env = Environments.newInstance(testsDirectory,
+                adjustEnvironmentConfig(new EnvironmentConfig().setLogFileSize(32768)));
+        store = (BitmapImpl) env.computeInTransaction(txn -> env.openBitmap("JHMBitMapBench", StoreConfig.WITHOUT_DUPLICATES, txn));
+
+        env.computeInTransaction(txn -> {
+            for (int i = 0; i < 100000; i++) {
+                store.set(txn, i * ThreadLocalRandom.current().nextInt(3), ThreadLocalRandom.current().nextBoolean());
+            }
+            return null;
+        });
+
+    }
+
+    @TearDown(Level.Iteration)
+    public void tearDown() {
+        if (env != null) {
+            env.close();
+            env = null;
+        }
+        if (temporaryFolder != null) {
+            temporaryFolder.delete();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @BenchmarkMode(Mode.Throughput)
+    @Benchmark
+    @Warmup(iterations = 5, time = 1)
+    @Measurement(iterations = 5, time = 1)
+    @Fork(1)
+    public long benchIterate() {
+        long v = 0;
+        Transaction txn = this.env.beginReadonlyTransaction();
+        try {
+
+            try (BitmapIterator iter = store.iterator(txn)) {
+                while (iter.hasNext()) {
+                    v += iter.nextLong();
+                }
+            }
+        } finally {
+            txn.abort();
+        }
+        return v;
+    }
+
+    private EnvironmentConfig adjustEnvironmentConfig(@NotNull EnvironmentConfig ec) {
+        ec.setUseVersion1Format(false);
+
+        return ec;
+    }
+}


### PR DESCRIPTION
The BitmapIterator purpose is to iterate over an indexed bit-set stored via Cursor, that is usually stored on a disk.

Use of nullable Long values for next/current values causes JVM to perform boxing/unboxing operations on the values causing unnecessary allocations.
See https://docs.oracle.com/javase/8/docs/technotes/guides/language/autoboxing.html

Difference in the benchmark:
```
Benchmark                                    Mode  Cnt     Score    Error  Units
Before: JMHBitmapIteratorBenchmark.iterate  thrpt    5  1454,327 ± 20,185  ops/s
After:  JMHBitmapIteratorBenchmark.iterate  thrpt    5  1542,706 ± 33,814  ops/s
```