### PR TITLE
Replace common shared counter in EntityIteratorBase with thread-local…

### DIFF
--- a/entity-store/src/main/java/jetbrains/exodus/entitystore/iterate/EntityIteratorBase.java
+++ b/entity-store/src/main/java/jetbrains/exodus/entitystore/iterate/EntityIteratorBase.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.NoSuchElementException;
+import java.util.concurrent.ThreadLocalRandom;
 
 @SuppressWarnings({"AssignmentToStaticFieldFromInstanceMethod"})
 public abstract class EntityIteratorBase implements EntityIterator {
@@ -46,8 +47,6 @@ public abstract class EntityIteratorBase implements EntityIterator {
             }
         };
     }
-
-    private static int nextIdCounter = 0;
 
     @NotNull
     private final EntityIterableBase iterable;
@@ -113,7 +112,7 @@ public abstract class EntityIteratorBase implements EntityIterator {
     @Nullable
     public EntityId nextId() {
         throwNoSuchElementExceptionIfNecessary();
-        if ((++nextIdCounter & 0x1ff) == 0) {
+        if (ThreadLocalRandom.current().nextInt(0x1ff) == 0) {
             // do not check QueryCancellingPolicy too often
             QueryCancellingPolicy.cancelIfNecessary(getQueryCancellingPolicy());
         }


### PR DESCRIPTION
… randomized check

Rationale:

In local setup, when the `sortedIssues` endpoint misses entity cache, the profile is dominated by cache-line ping-pong on 'nextIdCounter' that is updated simultaneously by all threads that iterate over any existing entity.

TODO: update the description to be more detailed when we are sure this change helps