### PR TITLE
Optimize PatriciaTraverser routine

### DIFF
--- a/environment/src/main/java/jetbrains/exodus/tree/patricia/PatriciaTraverser.java
+++ b/environment/src/main/java/jetbrains/exodus/tree/patricia/PatriciaTraverser.java
@@ -118,7 +118,8 @@ class PatriciaTraverser implements TreeTraverser {
         if (top == 0) {
             return currentNode.hasValue() ? currentNode.keySequence : ByteIterable.EMPTY;
         }
-        final LightOutputStream output = new LightOutputStream(7);
+        // The ~90% key size fits in 28 and anything else often gets almost immediately promoted to 28
+        final LightOutputStream output = new LightOutputStream(28);
         for (int i = 0; i < top; ++i) {
             ByteIterableBase.fillBytes(stack[i].getKey(), output);
             output.write(stack[i].getNode().firstByte); // seems that firstByte isn't mutated

--- a/openAPI/src/main/java/jetbrains/exodus/ByteIterableBase.java
+++ b/openAPI/src/main/java/jetbrains/exodus/ByteIterableBase.java
@@ -217,6 +217,9 @@ public abstract class ByteIterableBase implements ByteIterable {
     }
 
     public static void fillBytes(@NotNull final ByteIterable bi, @NotNull final LightOutputStream output) {
+        if (bi == EMPTY) {
+            return;
+        }
         if (bi instanceof ArrayByteIterable) {
             final ArrayByteIterable abi = (ArrayByteIterable) bi;
             final int length = abi.getLength();


### PR DESCRIPTION
* Pre-allocate bytearray of the corresponding size to avoid excessive garbage
* Short-circuit the most common path on fillBytes



### Motivation

It significantly speeds up the traversal on the following benchmark and, depending on the workload, is visible in hot profiles, both locally and in production:
```
@Threads(8) // Tune it 
@Warmup(iterations = 5, time = 1)
@Measurement(iterations = 5, time = 1)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Benchmark)
@Fork(2)
open class EntityIteratorBaseSharedCache {


    companion object {
        val instance: PersistentEntityStoreImpl

        init {
            val tmp = kotlin.io.path.createTempDirectory("EntityIteratorBaseSharedCache").toFile()
            instance = PersistentEntityStores.newInstance(tmp);

            val txn = instance.beginTransaction()
            for (i in 0..1_000_000) {
                val entity = txn.newEntity("Issue")
                entity.setProperty("description", "Test issue #$i")
                entity.setProperty("size", i)
            }
            txn.flush()
            txn.commit()
        }

        @JvmStatic
        fun main(args: Array<String>) {
            doIter()
            doIter()
            doIter()
            doIter()
        }

        private fun doIter() {
            var tx = instance.beginTransaction()
            for (entity in tx.getAll("Issue")) {
                if (Random.nextInt(100) == 1) {
                    tx.newEntity("Issue")
                }
            }
            tx.flush()
            tx.commit()
        }
    }

    val txn = ThreadLocal.withInitial { instance.beginTransaction() }


    @Benchmark
    @OutputTimeUnit(TimeUnit.MILLISECONDS)
    fun createCached(bh: Blackhole) {
        val tx = instance.beginTransaction()
        val all = tx.getAll("Issue") as EntityIterableBase
        for (entity in EntityIdArrayCachedInstanceIterableFactory.createInstance(tx, all)) {
            bh.consume(entity)
        }
        tx.commit()
    }


    @Benchmark
    fun iterate(bh: Blackhole) {
        val tx = txn.get()
        for (entity in tx.getAll("Issue")) {
            bh.consume(entity)
        }
       tx.commit()
    }
}

```