### PR TITLE
Make ODataMigrator, OEntityStore and OModelMetadata work together

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OPersistentEntityStore.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OPersistentEntityStore.kt
@@ -16,9 +16,7 @@
 package jetbrains.exodus.entitystore.orientdb
 
 import com.orientechnologies.orient.core.db.ODatabaseSession
-import com.orientechnologies.orient.core.metadata.schema.OClass
 import com.orientechnologies.orient.core.record.OVertex
-import com.orientechnologies.orient.core.sql.executor.OResultSet
 import jetbrains.exodus.backup.BackupStrategy
 import jetbrains.exodus.bindings.ComparableBinding
 import jetbrains.exodus.core.execution.MultiThreadDelegatingJobProcessor
@@ -32,7 +30,7 @@ class OPersistentEntityStore(
     val databaseProvider: ODatabaseProvider,
     private val name: String,
     override val countExecutor: Executor = Executors.newSingleThreadExecutor(),
-    private val classIdToOClassId: Map<Int, Int>
+    private val schemaBuddy: OSchemaBuddy = OSchemaBuddyImpl(databaseProvider)
 ) : PersistentEntityStore, OEntityStore {
 
     private val config = PersistentEntityStoreConfig()
@@ -56,7 +54,7 @@ class OPersistentEntityStore(
         val session = databaseProvider.acquireSession()
         session.activateOnCurrentThread()
         val txn = session.begin().transaction
-        return OStoreTransactionImpl(session, txn, this)
+        return OStoreTransactionImpl(session, txn, this, schemaBuddy)
     }
 
     override fun beginExclusiveTransaction(): StoreTransaction {
@@ -71,7 +69,8 @@ class OPersistentEntityStore(
         return OStoreTransactionImpl(
             ODatabaseSession.getActiveSession(),
             ODatabaseSession.getActiveSession().transaction,
-            this
+            this,
+            schemaBuddy
         )
     }
 
@@ -178,25 +177,7 @@ class OPersistentEntityStore(
     private val currentOTransaction get() = currentTransaction as OStoreTransaction
 
     fun getOEntityId(entityId: PersistentEntityId): ORIDEntityId {
-        // Keep in mind that it is possible that we are given an entityId that is not in the database.
-        // It is a valid case.
-
-        val oSession = ODatabaseSession.getActiveSession() ?: throw IllegalStateException("no active database session found")
-        val classId = entityId.typeId
-        val localEntityId = entityId.localId
-        val oClassId = classIdToOClassId[classId] ?: return ORIDEntityId.EMPTY_ID
-        val className = oSession.getClusterNameById(oClassId) ?: return ORIDEntityId.EMPTY_ID
-        val oClass = oSession.getClass(className) ?: return ORIDEntityId.EMPTY_ID
-
-        val resultSet: OResultSet = oSession.query("SELECT FROM $className WHERE ${OVertexEntity.LOCAL_ENTITY_ID_PROPERTY_NAME} = ?", localEntityId)
-        val oid = if (resultSet.hasNext()) {
-            val result = resultSet.next()
-            result.toVertex()?.identity ?: return ORIDEntityId.EMPTY_ID
-        } else {
-            return ORIDEntityId.EMPTY_ID
-        }
-
-        return ORIDEntityId(classId, localEntityId, oid, oClass)
+        return schemaBuddy.getOEntityId(entityId)
     }
 }
 
@@ -209,13 +190,5 @@ internal fun PersistentEntityStore.requireOEntityId(id: EntityId): ORIDEntityId 
             oEntityStore.getOEntityId(id)
         }
         else -> throw IllegalArgumentException("${id.javaClass.simpleName} is not supported")
-    }
-}
-
-fun ODatabaseSession.getClassIdToOClassIdMap(): Map<Int, Int> = buildMap {
-    for (oClass in metadata.schema.classes) {
-        if (oClass.isVertexType && oClass.name != OClass.VERTEX_CLASS_NAME) {
-            put(oClass.requireClassId(), oClass.defaultClusterId)
-        }
     }
 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddy.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddy.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.ConcurrentHashMap
 interface OSchemaBuddy {
     fun getOEntityId(entityId: PersistentEntityId): ORIDEntityId
     fun makeSureTypeExists(session: ODatabaseDocument, entityType: String)
+    fun initialize()
 }
 
 class OSchemaBuddyImpl(
@@ -31,7 +32,7 @@ class OSchemaBuddyImpl(
         }
     }
 
-    fun initialize() {
+    override fun initialize() {
         dbProvider.withCurrentOrNewSession { session ->
             session.createClassIdSequenceIfAbsent()
             for (oClass in session.metadata.schema.classes) {

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddy.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddy.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright ${inceptionYear} - ${year} ${owner}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jetbrains.exodus.entitystore.orientdb
 
 import com.orientechnologies.orient.core.db.ODatabaseSession

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddy.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddy.kt
@@ -1,0 +1,123 @@
+package jetbrains.exodus.entitystore.orientdb
+
+import com.orientechnologies.orient.core.db.ODatabaseSession
+import com.orientechnologies.orient.core.db.document.ODatabaseDocument
+import com.orientechnologies.orient.core.metadata.schema.OClass
+import com.orientechnologies.orient.core.metadata.sequence.OSequence
+import com.orientechnologies.orient.core.record.OVertex
+import com.orientechnologies.orient.core.sql.executor.OResultSet
+import jetbrains.exodus.entitystore.PersistentEntityId
+import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.CLASS_ID_CUSTOM_PROPERTY_NAME
+import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.CLASS_ID_SEQUENCE_NAME
+import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.LOCAL_ENTITY_ID_PROPERTY_NAME
+import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.localEntityIdSequenceName
+import java.util.concurrent.ConcurrentHashMap
+
+interface OSchemaBuddy {
+    fun getOEntityId(entityId: PersistentEntityId): ORIDEntityId
+    fun makeSureTypeExists(session: ODatabaseDocument, entityType: String)
+}
+
+class OSchemaBuddyImpl(
+    private val dbProvider: ODatabaseProvider,
+    autoInitialize: Boolean = true,
+): OSchemaBuddy {
+
+    private val classIdToOClassId = ConcurrentHashMap<Int, Int>()
+
+    init {
+        if (autoInitialize) {
+            initialize()
+        }
+    }
+
+    fun initialize() {
+        dbProvider.withCurrentOrNewSession { session ->
+            session.createClassIdSequenceIfAbsent()
+            for (oClass in session.metadata.schema.classes) {
+                if (oClass.isVertexType && oClass.name != OClass.VERTEX_CLASS_NAME) {
+                    classIdToOClassId.put(oClass.requireClassId(), oClass.defaultClusterId)
+                }
+            }
+        }
+    }
+
+    override fun getOEntityId(entityId: PersistentEntityId): ORIDEntityId {
+        // Keep in mind that it is possible that we are given an entityId that is not in the database.
+        // It is a valid case.
+
+        val oSession = ODatabaseSession.getActiveSession() ?: throw IllegalStateException("no active database session found")
+        val classId = entityId.typeId
+        val localEntityId = entityId.localId
+        val oClassId = classIdToOClassId[classId] ?: return ORIDEntityId.EMPTY_ID
+        val className = oSession.getClusterNameById(oClassId) ?: return ORIDEntityId.EMPTY_ID
+        val oClass = oSession.getClass(className) ?: return ORIDEntityId.EMPTY_ID
+
+        val resultSet: OResultSet = oSession.query("SELECT FROM $className WHERE $LOCAL_ENTITY_ID_PROPERTY_NAME = ?", localEntityId)
+        val oid = if (resultSet.hasNext()) {
+            val result = resultSet.next()
+            result.toVertex()?.identity ?: return ORIDEntityId.EMPTY_ID
+        } else {
+            return ORIDEntityId.EMPTY_ID
+        }
+
+        return ORIDEntityId(classId, localEntityId, oid, oClass)
+    }
+
+    override fun makeSureTypeExists(session: ODatabaseDocument, entityType: String) {
+        session.getOrCreateVertexClass(entityType)
+    }
+
+}
+
+fun ODatabaseDocument.createClassIdSequenceIfAbsent(startFrom: Long = 0L) {
+    createSequenceIfAbsent(CLASS_ID_SEQUENCE_NAME, startFrom)
+}
+
+fun ODatabaseDocument.createLocalEntityIdSequenceIfAbsent(oClass: OClass, startFrom: Long = 0L) {
+    createSequenceIfAbsent(localEntityIdSequenceName(oClass.name), startFrom)
+}
+
+fun ODatabaseDocument.createSequenceIfAbsent(sequenceName: String, startFrom: Long = 0L) {
+    val sequences = metadata.sequenceLibrary
+    if (sequences.getSequence(sequenceName) == null) {
+        val params = OSequence.CreateParams()
+        params.start = startFrom
+        sequences.createSequence(sequenceName, OSequence.SEQUENCE_TYPE.ORDERED, params)
+    }
+}
+
+fun ODatabaseDocument.setClassIdIfAbsent(oClass: OClass) {
+    if (oClass.getCustom(CLASS_ID_CUSTOM_PROPERTY_NAME) == null) {
+        val sequences = metadata.sequenceLibrary
+        val sequence: OSequence = sequences.getSequence(CLASS_ID_SEQUENCE_NAME) ?: throw IllegalStateException("$CLASS_ID_SEQUENCE_NAME not found")
+
+        oClass.setCustom(CLASS_ID_CUSTOM_PROPERTY_NAME, sequence.next().toString())
+    }
+}
+
+fun ODatabaseDocument.setLocalEntityIdIfAbsent(vertex: OVertex) {
+    if (vertex.getProperty<Long>(LOCAL_ENTITY_ID_PROPERTY_NAME) == null) {
+        val oClass = vertex.requireSchemaClass()
+        setLocalEntityId(oClass.name, vertex)
+    }
+}
+
+fun ODatabaseDocument.setLocalEntityId(className: String, vertex: OVertex) {
+    val sequences = metadata.sequenceLibrary
+    val sequenceName = localEntityIdSequenceName(className)
+    val sequence: OSequence = sequences.getSequence(sequenceName) ?: throw IllegalStateException("$sequenceName not found")
+    vertex.setProperty(LOCAL_ENTITY_ID_PROPERTY_NAME, sequence.next())
+}
+
+fun ODatabaseDocument.getOrCreateVertexClass(className: String): OClass {
+    val existingClass = this.getClass(className)
+    if (existingClass != null) return existingClass
+
+    requireNoActiveTransaction()
+    createClassIdSequenceIfAbsent()
+    val oClass = createVertexClass(className)
+    setClassIdIfAbsent(oClass)
+    createLocalEntityIdSequenceIfAbsent(oClass)
+    return oClass
+}

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
@@ -34,7 +34,8 @@ import jetbrains.exodus.env.Transaction
 class OStoreTransactionImpl(
     private val session: ODatabaseDocument,
     private val txn: OTransaction,
-    private val store: PersistentEntityStore
+    private val store: PersistentEntityStore,
+    private val schemaBuddy: OSchemaBuddy
 ) : OStoreTransaction {
 
     private var queryCancellingPolicy: QueryCancellingPolicy? = null
@@ -92,6 +93,7 @@ class OStoreTransactionImpl(
     }
 
     override fun newEntity(entityType: String): Entity {
+        schemaBuddy.makeSureTypeExists(session, entityType)
         val vertex = session.newVertex(entityType)
         session.setLocalEntityId(entityType, vertex)
         return OVertexEntity(vertex, store)

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
@@ -28,12 +28,8 @@ import jetbrains.exodus.entitystore.Entity
 import jetbrains.exodus.entitystore.EntityId
 import jetbrains.exodus.entitystore.EntityIterable
 import jetbrains.exodus.entitystore.PersistentEntityStore
-import jetbrains.exodus.entitystore.*
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.CLASS_ID_CUSTOM_PROPERTY_NAME
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.LOCAL_ENTITY_ID_PROPERTY_NAME
-import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.CLASS_ID_SEQUENCE_NAME
-import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.LOCAL_ENTITY_ID_PROPERTY_NAME
-import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.localEntityIdSequenceName
 import jetbrains.exodus.entitystore.orientdb.iterate.link.OVertexEntityIterable
 import mu.KLogging
 import java.io.ByteArrayInputStream

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
@@ -16,21 +16,20 @@
 package jetbrains.exodus.entitystore.orientdb
 
 import com.orientechnologies.orient.core.db.ODatabaseSession
-import com.orientechnologies.orient.core.db.document.ODatabaseDocument
 import com.orientechnologies.orient.core.db.record.OIdentifiable
 import com.orientechnologies.orient.core.id.ORecordId
 import com.orientechnologies.orient.core.metadata.schema.OClass
-import com.orientechnologies.orient.core.metadata.sequence.OSequence
 import com.orientechnologies.orient.core.record.ODirection
 import com.orientechnologies.orient.core.record.OEdge
 import com.orientechnologies.orient.core.record.OElement
 import com.orientechnologies.orient.core.record.OVertex
 import jetbrains.exodus.ByteIterable
-import jetbrains.exodus.entitystore.*
-import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.LOCAL_ENTITY_ID_PROPERTY_NAME
+import jetbrains.exodus.entitystore.Entity
+import jetbrains.exodus.entitystore.EntityId
+import jetbrains.exodus.entitystore.EntityIterable
+import jetbrains.exodus.entitystore.PersistentEntityStore
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.CLASS_ID_CUSTOM_PROPERTY_NAME
-import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.CLASS_ID_SEQUENCE_NAME
-import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.localEntityIdSequenceName
+import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.LOCAL_ENTITY_ID_PROPERTY_NAME
 import jetbrains.exodus.entitystore.orientdb.iterate.link.OVertexEntityIterable
 import mu.KLogging
 import java.io.ByteArrayInputStream
@@ -343,57 +342,6 @@ class OVertexEntity(private var vertex: OVertex, private val store: PersistentEn
     }
 
     private fun OVertex?.toOEntityOrNull(): OEntity? = this?.let { OVertexEntity(this, store) }
-}
-
-fun ODatabaseSession.createClassIdSequenceIfAbsent(startFrom: Long = 0L) {
-    createSequenceIfAbsent(CLASS_ID_SEQUENCE_NAME, startFrom)
-}
-
-fun ODatabaseSession.createLocalEntityIdSequenceIfAbsent(oClass: OClass, startFrom: Long = 0L) {
-    createSequenceIfAbsent(localEntityIdSequenceName(oClass.name), startFrom)
-}
-
-fun ODatabaseSession.createSequenceIfAbsent(sequenceName: String, startFrom: Long = 0L) {
-    val sequences = metadata.sequenceLibrary
-    if (sequences.getSequence(sequenceName) == null) {
-        val params = OSequence.CreateParams()
-        params.start = startFrom
-        sequences.createSequence(sequenceName, OSequence.SEQUENCE_TYPE.ORDERED, params)
-    }
-}
-
-fun ODatabaseSession.setClassIdIfAbsent(oClass: OClass) {
-    if (oClass.getCustom(CLASS_ID_CUSTOM_PROPERTY_NAME) == null) {
-        val sequences = metadata.sequenceLibrary
-        val sequence: OSequence = sequences.getSequence(CLASS_ID_SEQUENCE_NAME) ?: throw IllegalStateException("$CLASS_ID_SEQUENCE_NAME not found")
-
-        oClass.setCustom(CLASS_ID_CUSTOM_PROPERTY_NAME, sequence.next().toString())
-    }
-}
-
-fun ODatabaseSession.setLocalEntityIdIfAbsent(vertex: OVertex) {
-    if (vertex.getProperty<Long>(LOCAL_ENTITY_ID_PROPERTY_NAME) == null) {
-        val oClass = vertex.requireSchemaClass()
-        setLocalEntityId(oClass.name, vertex)
-    }
-}
-
-fun ODatabaseDocument.setLocalEntityId(className: String, vertex: OVertex) {
-    val sequences = metadata.sequenceLibrary
-    val sequenceName = localEntityIdSequenceName(className)
-    val sequence: OSequence = sequences.getSequence(sequenceName) ?: throw IllegalStateException("$sequenceName not found")
-    vertex.setProperty(LOCAL_ENTITY_ID_PROPERTY_NAME, sequence.next())
-}
-
-fun ODatabaseSession.getOrCreateVertexClass(className: String): OClass {
-    val existingClass = this.getClass(className)
-    if (existingClass != null) return existingClass
-
-    createClassIdSequenceIfAbsent()
-    val oClass = createVertexClass(className)
-    setClassIdIfAbsent(oClass)
-    createLocalEntityIdSequenceIfAbsent(oClass)
-    return oClass
 }
 
 fun OClass.requireClassId(): Int {

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OPersistentStoreTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OPersistentStoreTest.kt
@@ -76,7 +76,7 @@ class OPersistentStoreTest: OTestMixin {
             assertEquals(1, sequence.increment())
         }
         store.executeInTransaction {
-            assertEquals(1,it.getSequence("first").get())
+            assertEquals(1, it.getSequence("first").get())
         }
     }
 
@@ -92,7 +92,7 @@ class OPersistentStoreTest: OTestMixin {
     }
 
     @Test
-    fun `can set actual value to sequence`(){
+    fun `can set actual value to sequence`() {
         val store = orientDb.store
         val sequence = store.computeInTransaction {
             it.getSequence("first", 99)

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddyTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddyTest.kt
@@ -1,0 +1,76 @@
+package jetbrains.exodus.entitystore.orientdb
+
+import com.orientechnologies.orient.core.metadata.sequence.OSequence
+import jetbrains.exodus.entitystore.PersistentEntityId
+import jetbrains.exodus.entitystore.orientdb.testutil.InMemoryOrientDB
+import jetbrains.exodus.entitystore.orientdb.testutil.createIssue
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.junit.Rule
+
+class OSchemaBuddyTest {
+
+    @Rule
+    @JvmField
+    val orientDb = InMemoryOrientDB(initializeIssueSchema = false)
+
+    @Test
+    fun `if autoInitialize is false, explicit initialization is required`() {
+        val issueId = orientDb.createIssue("trista").id
+        val buddy = OSchemaBuddyImpl(orientDb.provider, autoInitialize = false)
+
+        val totallyExistingEntityId = PersistentEntityId(issueId.typeId, issueId.localId)
+        orientDb.withSession {
+            assertEquals(ORIDEntityId.EMPTY_ID, buddy.getOEntityId(totallyExistingEntityId))
+        }
+
+        buddy.initialize()
+
+        orientDb.withSession {
+            assertEquals(issueId, buddy.getOEntityId(totallyExistingEntityId))
+        }
+    }
+
+    @Test
+    fun `getOEntityId() works with both existing and not existing EntityId`() {
+        val issueId = orientDb.createIssue("trista").id
+        val buddy = OSchemaBuddyImpl(orientDb.provider, autoInitialize = true)
+
+        val notExistingEntityId = PersistentEntityId(300, 301)
+        val partiallyExistingEntityId1 = PersistentEntityId(issueId.typeId, 301)
+        val partiallyExistingEntityId2 = PersistentEntityId(300, issueId.localId)
+        val totallyExistingEntityId = PersistentEntityId(issueId.typeId, issueId.localId)
+        orientDb.withSession {
+            assertEquals(ORIDEntityId.EMPTY_ID, buddy.getOEntityId(notExistingEntityId))
+            assertEquals(ORIDEntityId.EMPTY_ID, buddy.getOEntityId(partiallyExistingEntityId1))
+            assertEquals(ORIDEntityId.EMPTY_ID, buddy.getOEntityId(partiallyExistingEntityId2))
+            assertEquals(issueId, buddy.getOEntityId(totallyExistingEntityId))
+        }
+    }
+
+    /*
+    * SchemaBuddy heavily depends on this invariant for the classId map consistency
+    * */
+    @Test
+    fun `sequence does not roll back already generated values if the transaction is rolled back`() {
+        orientDb.withSession { session ->
+            val params = OSequence.CreateParams()
+            params.start = 0
+            session.metadata.sequenceLibrary.createSequence("seq", OSequence.SEQUENCE_TYPE.ORDERED, params)
+        }
+
+        orientDb.withTxSession { session ->
+            val res = session.metadata.sequenceLibrary.getSequence("seq").next()
+            assertEquals(1, res)
+            session.rollback()
+        }
+
+        orientDb.withTxSession { session ->
+            val res = session.metadata.sequenceLibrary.getSequence("seq").next()
+            assertEquals(2, res)
+            session.rollback()
+        }
+    }
+
+}

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddyTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddyTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright ${inceptionYear} - ${year} ${owner}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jetbrains.exodus.entitystore.orientdb
 
 import com.orientechnologies.orient.core.metadata.sequence.OSequence

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddyTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OSchemaBuddyTest.kt
@@ -33,6 +33,20 @@ class OSchemaBuddyTest {
     }
 
     @Test
+    fun `buddy properly creates a class if absent`() {
+        val buddy = OSchemaBuddyImpl(orientDb.provider)
+        val className = "trista"
+        orientDb.withSession { session ->
+            assertNull(session.getClass(className))
+            buddy.makeSureTypeExists(session, className)
+            val oClass = session.getClass(className)
+            assertNotNull(oClass)
+            assertNotNull(oClass.getCustom(OVertexEntity.CLASS_ID_CUSTOM_PROPERTY_NAME))
+            assertNotNull(session.metadata.sequenceLibrary.getSequence(OVertexEntity.localEntityIdSequenceName(className)))
+        }
+    }
+
+    @Test
     fun `getOEntityId() works with both existing and not existing EntityId`() {
         val issueId = orientDb.createIssue("trista").id
         val buddy = OSchemaBuddyImpl(orientDb.provider, autoInitialize = true)

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionTest.kt
@@ -33,7 +33,7 @@ class OStoreTransactionTest : OTestMixin {
 
     @Rule
     @JvmField
-    val orientDbRule = InMemoryOrientDB()
+    val orientDbRule = InMemoryOrientDB(true)
 
     override val orientDb = orientDbRule
 
@@ -577,6 +577,18 @@ class OStoreTransactionTest : OTestMixin {
         orientDb.store.executeInTransaction { tx ->
             val issue = tx.newEntity(Issues.CLASS)
             assertEquals(issue.id.localId, 1)
+        }
+    }
+
+    /*
+    * This behaviour may change in the future if we support schema changes in transactions
+    * */
+    @Test
+    fun `newEntity() throws exception if the type is not created`() {
+        orientDb.store.executeInTransaction { tx ->
+            assertFailsWith<AssertionError> {
+                tx.newEntity("opca")
+            }
         }
     }
 }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/InMemoryOrientDB.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/InMemoryOrientDB.kt
@@ -22,13 +22,15 @@ import com.orientechnologies.orient.core.db.OrientDBConfig
 import com.orientechnologies.orient.core.sql.executor.OResultSet
 import jetbrains.exodus.entitystore.orientdb.ODatabaseProviderImpl
 import jetbrains.exodus.entitystore.orientdb.OPersistentEntityStore
+import jetbrains.exodus.entitystore.orientdb.OSchemaBuddyImpl
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.BINARY_BLOB_CLASS_NAME
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.STRING_BLOB_CLASS_NAME
 import jetbrains.exodus.entitystore.orientdb.getOrCreateVertexClass
 import org.junit.rules.ExternalResource
 
 class InMemoryOrientDB(
-    private val initializeIssueSchema: Boolean = true
+    private val initializeIssueSchema: Boolean = true,
+    private val autoInitializeSchemaBuddy: Boolean = true
 ) : ExternalResource() {
 
     private lateinit var db: OrientDB
@@ -56,7 +58,9 @@ class InMemoryOrientDB(
         }
 
         provider = ODatabaseProviderImpl(database, dbName, username, password, ODatabaseType.MEMORY)
-        store = OPersistentEntityStore(provider, dbName)
+        store = OPersistentEntityStore(provider, dbName,
+            schemaBuddy = OSchemaBuddyImpl(provider, autoInitialize = autoInitializeSchemaBuddy)
+        )
     }
 
     override fun after() {

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/InMemoryOrientDB.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/InMemoryOrientDB.kt
@@ -24,7 +24,6 @@ import jetbrains.exodus.entitystore.orientdb.ODatabaseProviderImpl
 import jetbrains.exodus.entitystore.orientdb.OPersistentEntityStore
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.BINARY_BLOB_CLASS_NAME
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.STRING_BLOB_CLASS_NAME
-import jetbrains.exodus.entitystore.orientdb.getClassIdToOClassIdMap
 import jetbrains.exodus.entitystore.orientdb.getOrCreateVertexClass
 import org.junit.rules.ExternalResource
 
@@ -46,19 +45,18 @@ class InMemoryOrientDB(
         db = OrientDB("memory", OrientDBConfig.defaultConfig())
         db.execute("create database $dbName MEMORY users ( $username identified by '$password' role admin )")
 
-        val classIdToOClassId = if (initializeIssueSchema) {
+        if (initializeIssueSchema) {
             withSession { session ->
                 session.getOrCreateVertexClass(Issues.CLASS)
                 session.getOrCreateVertexClass(Boards.CLASS)
                 session.getOrCreateVertexClass(Projects.CLASS)
                 session.createClass(STRING_BLOB_CLASS_NAME)
                 session.createClass(BINARY_BLOB_CLASS_NAME)
-                session.getClassIdToOClassIdMap()
             }
-        } else mapOf()
+        }
 
         provider = ODatabaseProviderImpl(database, dbName, username, password, ODatabaseType.MEMORY)
-        store = OPersistentEntityStore(provider, dbName, classIdToOClassId = classIdToOClassId)
+        store = OPersistentEntityStore(provider, dbName)
     }
 
     override fun after() {
@@ -72,7 +70,9 @@ class InMemoryOrientDB(
         try {
             session.begin()
             val result = block(session)
-            session.commit()
+            if (session.transaction.isActive) {
+                session.commit()
+            }
             return result
         } finally {
             session.close()

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OrientDBIssues.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OrientDBIssues.kt
@@ -97,7 +97,7 @@ fun InMemoryOrientDB.addIssueToBoard(issue: OEntity, board: OEntity) {
     }
 }
 
-private fun ODatabaseSession.createNamedEntity(
+fun ODatabaseSession.createNamedEntity(
     className: String,
     name: String,
     store: PersistentEntityStore

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateDataTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateDataTest.kt
@@ -20,6 +20,7 @@ import com.orientechnologies.orient.core.record.impl.ODocument
 import com.orientechnologies.orient.core.record.impl.OVertexDocument
 import jetbrains.exodus.entitystore.StoreTransaction
 import jetbrains.exodus.entitystore.XodusTestDB
+import jetbrains.exodus.entitystore.orientdb.OPersistentEntityStore
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.CLASS_ID_SEQUENCE_NAME
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.localEntityIdSequenceName
@@ -61,7 +62,7 @@ class MigrateDataTest {
         migrateDataFromXodusToOrientDb(xodus.store, orientDb.store)
 
         orientDb.withSession { oSession ->
-            oSession.assertOrientContainsAllTheEntities(entities)
+            oSession.assertOrientContainsAllTheEntities(entities, orientDb.store)
         }
     }
 
@@ -84,7 +85,7 @@ class MigrateDataTest {
         migrateDataFromXodusToOrientDb(xodus.store, orientDb.store)
 
         orientDb.withSession { oSession ->
-            oSession.assertOrientContainsAllTheEntities(entities)
+            oSession.assertOrientContainsAllTheEntities(entities, orientDb.store)
         }
     }
 
@@ -119,7 +120,7 @@ class MigrateDataTest {
         migrateDataFromXodusToOrientDb(xodus.store, orientDb.store)
 
         orientDb.withSession { oSession ->
-            oSession.assertOrientContainsAllTheEntities(entities)
+            oSession.assertOrientContainsAllTheEntities(entities, orientDb.store)
         }
     }
 
@@ -202,68 +203,69 @@ class MigrateDataTest {
         }
     }
 
-    private fun ODatabaseSession.assertOrientContainsAllTheEntities(pile: PileOfEntities) {
-        for (type in pile.types) {
-            for (record in this.browseClass(type)) {
-                val entity = pile.getEntity(type, record.getTestId())
-                record.assertEquals(entity)
-            }
+}
+
+internal fun ODatabaseSession.assertOrientContainsAllTheEntities(pile: PileOfEntities, entityStore: OPersistentEntityStore) {
+    for (type in pile.types) {
+        for (record in this.browseClass(type)) {
+            val entity = pile.getEntity(type, record.getTestId())
+            record.assertEquals(entity, entityStore)
         }
     }
+}
 
-    private fun ODocument.assertEquals(expected: Entity) {
-        val actualDocument = this
-        val actual = OVertexEntity(actualDocument as OVertexDocument, orientDb.store)
+internal fun ODocument.assertEquals(expected: Entity, entityStore: OPersistentEntityStore) {
+    val actualDocument = this
+    val actual = OVertexEntity(actualDocument as OVertexDocument, entityStore)
 
-        Assert.assertEquals(expected.id, actualDocument.getTestId())
-        for ((propName, propValue) in expected.props) {
-            Assert.assertEquals(propValue, actual.getProperty(propName))
-        }
-        for ((blobName, blobValue) in expected.blobs) {
-            val actualValue = actual.getBlob(blobName)!!.readAllBytes()
-            Assert.assertEquals(blobValue, actualValue.decodeToString())
-        }
-
-        for (expectedLink in expected.links) {
-            val actualLinks = actual.getLinks(expectedLink.name).toList()
-            val tartedActual = actualLinks.first { it.getProperty("id") == expectedLink.targetId }
-            Assert.assertEquals(expectedLink.targetType, tartedActual.type)
-        }
+    Assert.assertEquals(expected.id, actualDocument.getTestId())
+    for ((propName, propValue) in expected.props) {
+        Assert.assertEquals(propValue, actual.getProperty(propName))
+    }
+    for ((blobName, blobValue) in expected.blobs) {
+        val actualValue = actual.getBlob(blobName)!!.readAllBytes()
+        Assert.assertEquals(blobValue, actualValue.decodeToString())
     }
 
-    private fun ODocument.getTestId(): Int = getProperty("id")
+    for (expectedLink in expected.links) {
+        val actualLinks = actual.getLinks(expectedLink.name).toList()
+        val tartedActual = actualLinks.first { it.getProperty("id") == expectedLink.targetId }
+        Assert.assertEquals(expectedLink.targetType, tartedActual.type)
+    }
+}
 
-    private fun StoreTransaction.createEntities(pile: PileOfEntities) {
-        for (type in pile.types) {
-            for (entity in pile.getAll(type)) {
-                this.createEntity(entity)
-            }
-        }
-        for (type in pile.types) {
-            for (entity in pile.getAll(type)) {
-                this.createLinks(entity)
-            }
+internal fun ODocument.getTestId(): Int = getProperty("id")
+
+internal fun StoreTransaction.createEntities(pile: PileOfEntities) {
+    for (type in pile.types) {
+        for (entity in pile.getAll(type)) {
+            this.createEntity(entity)
         }
     }
-
-    private fun StoreTransaction.createEntity(entity: Entity) {
-        val e = this.newEntity(entity.type)
-        e.setProperty("id", entity.id)
-
-        for ((name, value) in entity.props) {
-            e.setProperty(name, value)
-        }
-        for ((name, value) in entity.blobs) {
-            e.setBlob(name, ByteArrayInputStream(value.encodeToByteArray()))
+    for (type in pile.types) {
+        for (entity in pile.getAll(type)) {
+            this.createLinks(entity)
         }
     }
+}
 
-    private fun StoreTransaction.createLinks(entity: Entity) {
-        val xEntity = this.getAll(entity.type).first { it.getProperty("id") == entity.id }
-        for (link in entity.links) {
-            val targetXEntity = this.getAll(link.targetType).first { it.getProperty("id") == link.targetId }
-            xEntity.addLink(link.name, targetXEntity)
-        }
+internal fun StoreTransaction.createEntity(entity: Entity) {
+    val e = this.newEntity(entity.type)
+    e.setProperty("id", entity.id)
+
+    for ((name, value) in entity.props) {
+        e.setProperty(name, value)
+    }
+    for ((name, value) in entity.blobs) {
+        e.setBlob(name, ByteArrayInputStream(value.encodeToByteArray()))
+    }
+}
+
+internal fun StoreTransaction.createLinks(entity: Entity) {
+    val xEntity = this.getAll(entity.type).first { it.getProperty("id") == entity.id }
+    for (link in entity.links) {
+        val targetXEntity = this.getAll(link.targetType).first { it.getProperty("id") == link.targetId }
+        xEntity.addLink(link.name, targetXEntity)
     }
 }
 

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateDataTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateDataTest.kt
@@ -37,7 +37,7 @@ class MigrateDataTest {
 
     @Rule
     @JvmField
-    val orientDb = InMemoryOrientDB(initializeIssueSchema = false)
+    val orientDb = InMemoryOrientDB(initializeIssueSchema = false, autoInitializeSchemaBuddy = false)
 
     @Rule
     @JvmField

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright ${inceptionYear} - ${year} ${owner}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jetbrains.exodus.query.metadata
 
 import com.orientechnologies.orient.core.db.ODatabaseType

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
@@ -1,0 +1,161 @@
+package jetbrains.exodus.query.metadata
+
+import com.orientechnologies.orient.core.db.ODatabaseType
+import com.orientechnologies.orient.core.db.OrientDB
+import com.orientechnologies.orient.core.db.OrientDBConfig
+import com.orientechnologies.orient.core.record.ODirection
+import com.orientechnologies.orient.core.record.OVertex
+import jetbrains.exodus.TestUtil
+import jetbrains.exodus.entitystore.PersistentEntityStoreImpl
+import jetbrains.exodus.entitystore.PersistentEntityStores
+import jetbrains.exodus.entitystore.orientdb.*
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MigrateXodusToOrientDbSmokeTest {
+
+    @Test
+    fun `migrate data and schema from Xodus to OrientDB`() {
+
+        // 1. Where we migrate the data to
+
+        // 1.1 Create ODatabaseProvider
+        // params you need to provide through configs
+        val username = "admin"
+        val password = "password"
+        val dbName = "testDB"
+        val url = "memory"
+        // create the database
+        val db = OrientDB(url, OrientDBConfig.defaultConfig())
+        db.execute("create database $dbName MEMORY users ( $username identified by '$password' role admin )")
+        // create a provider
+        val dbProvider = ODatabaseProviderImpl(db, dbName, username, password, ODatabaseType.MEMORY)
+
+        // 1.2 Create OModelMetadata
+        // it is important to disable autoInitialize for the schemaBuddy,
+        // dataMigrator does not like anything existing in the database before it migrated the data
+        val oModelMetadata = OModelMetaData(dbProvider, OSchemaBuddyImpl(dbProvider, autoInitialize = false))
+
+        // 1.3 Create OPersistentEntityStore
+        // it is important to pass the oModelMetadata to the entityStore as schemaBuddy.
+        // it (oModelMetadata) must handle all the schema-related logic.
+        val oEntityStore = OPersistentEntityStore(dbProvider, dbName, schemaBuddy = oModelMetadata)
+
+        // 1.4 Create TransientEntityStore
+        // val oTransientEntityStore = TransientEntityStoreImpl(oModelMetadata, oEntityStore)
+
+
+        // 2. Where we migrate the data from
+
+        // 2.1 Create PersistentEntityStoreImpl
+        val fromDatabaseFolder = File(TestUtil.createTempDir().absolutePath)
+        val xEntityStore = PersistentEntityStores.newInstance(fromDatabaseFolder)
+        // for the test purposes
+        val entities = xEntityStore.createTestData()
+
+
+        // 3. Migrate the data
+        migrateDataFromXodusToOrientDb(xEntityStore, oEntityStore)
+
+
+        // 4. Initialize the schema
+        // initMetaData(XdModel.hierarchy, oTransientEntityStore)
+        // we do not have here neither TransientEntityStore nor initMetaData(...),
+        // so we will apply the schema directly
+        oModelMetadata.createTestSchema()
+        oModelMetadata.prepare()
+
+        // quick validations
+        oEntityStore.checkContainsAllTheEntities(entities)
+        oEntityStore.checkLinksWork()
+        oEntityStore.checkSchemaCreated()
+
+        // cleanup
+        xEntityStore.close()
+        fromDatabaseFolder.deleteRecursively()
+        db.close()
+    }
+
+    private fun OPersistentEntityStore.checkContainsAllTheEntities(entities: PileOfEntities) {
+        databaseProvider.withSession { session ->
+            session.assertOrientContainsAllTheEntities(entities, this)
+        }
+    }
+
+    private fun OPersistentEntityStore.checkSchemaCreated() {
+        databaseProvider.withSession { session ->
+            val type1 = session.getClass("type1")!!
+            val type2 = session.getClass("type2")!!
+
+            assertTrue(type1.existsProperty("prop4"))
+            assertTrue(type1.existsProperty(OVertex.getDirectEdgeLinkFieldName(ODirection.IN, "link1")))
+            assertTrue(type1.existsProperty(OVertex.getDirectEdgeLinkFieldName(ODirection.OUT, "link1")))
+
+            assertTrue(type2.existsProperty("pop4"))
+            assertTrue(type2.existsProperty(OVertex.getDirectEdgeLinkFieldName(ODirection.OUT, "link1")))
+        }
+    }
+
+    private fun OPersistentEntityStore.checkLinksWork() {
+        executeInTransaction { tx ->
+            for (entity in tx.getAll("type2")) {
+                if (entity.getProperty("id") == 7) {
+                    val targetEntity = entity.getLink("link1")!!
+
+                    assertEquals(6, targetEntity.getProperty("id"))
+                    assertEquals("type1", targetEntity.type)
+                }
+            }
+            for (entity in tx.getAll("type1")) {
+                if (entity.getProperty("id") == 6) {
+                    val targetEntity = entity.getLink("link1")!!
+
+                    assertEquals(2, targetEntity.getProperty("id"))
+                    assertEquals("type1", targetEntity.type)
+                }
+            }
+        }
+    }
+
+    private fun OModelMetaData.createTestSchema() {
+        entity("type1") {
+            property("prop1", "string")
+            property("prop2", "boolean")
+            property("prop3", "double")
+            property("prop4", "string")
+            association("link1", "type1", AssociationEndCardinality._0_n)
+        }
+        entity("type2") {
+            property("pop1", "string")
+            property("pop2", "boolean")
+            property("pop3", "double")
+            property("pop4", "string")
+            association("link1", "type1", AssociationEndCardinality._0_n)
+        }
+    }
+
+    private fun PersistentEntityStoreImpl.createTestData(): PileOfEntities {
+        val entities = pileOfEntities(
+            eProps("type1", 1, "prop1" to "one", "prop2" to true, "prop3" to 1.1),
+            eProps("type1", 2, "prop1" to "two", "prop2" to true, "prop3" to 2.2),
+            eProps("type1", 3, "prop1" to "three", "prop2" to true, "prop3" to 3.3),
+
+            eProps("type2", 2, "pop1" to "four", "pop2" to true, "pop3" to 2.2),
+            eProps("type2", 4, "pop1" to "five", "pop2" to true, "pop3" to 3.3),
+            eProps("type2", 5, "pop1" to "six", "pop2" to true, "pop3" to 4.4),
+
+            eLinks("type1", 6,
+                Link("link1", "type1", 2)
+            ),
+            eLinks("type2", 7,
+                Link("link1", "type1", 6),
+            )
+        )
+        computeInTransaction { tx ->
+            tx.createEntities(entities)
+        }
+        return entities
+    }
+}

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
@@ -125,15 +125,16 @@ class MigrateXodusToOrientDbSmokeTest {
             property("prop2", "boolean")
             property("prop3", "double")
             property("prop4", "string")
-            association("link1", "type1", AssociationEndCardinality._0_n)
         }
         entity("type2") {
             property("pop1", "string")
             property("pop2", "boolean")
             property("pop3", "double")
             property("pop4", "string")
-            association("link1", "type1", AssociationEndCardinality._0_n)
         }
+
+        association("type1","link1", "type1", AssociationEndCardinality._0_n)
+        association("type2","link1", "type1", AssociationEndCardinality._0_n)
     }
 
     private fun PersistentEntityStoreImpl.createTestData(): PileOfEntities {

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OModelMetaDataTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OModelMetaDataTest.kt
@@ -55,9 +55,8 @@ class OModelMetaDataTest {
     fun `addAssociation() implicitly call prepare() and applies the schema to OrientDB`() {
         oModel(orientDb.provider) {
             entity("type1")
-            entity("type2") {
-                association("ass1", "type1", AssociationEndCardinality._1)
-            }
+            entity("type2")
+            association("type2", "ass1", "type1", AssociationEndCardinality._1)
         }
 
         orientDb.withSession { session ->
@@ -134,9 +133,8 @@ class OModelMetaDataTest {
     fun removeAssociation() {
         val model = oModel(orientDb.provider) {
             entity("type1")
-            entity("type2") {
-                association("ass1", "type1", AssociationEndCardinality._1)
-            }
+            entity("type2")
+            association("type2", "ass1", "type1", AssociationEndCardinality._1)
         }
 
         model.removeAssociation("type2", "ass1")

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
@@ -180,10 +180,9 @@ class OrientDbSchemaInitializerTest {
     fun `one-directional associations`(): Unit = orientDb.withSession { oSession ->
         val model = model {
             entity("type1")
-            entity("type2") {
-                for (cardinality in AssociationEndCardinality.entries) {
-                    association("prop1$cardinality", "type1", cardinality)
-                }
+            entity("type2")
+            for (cardinality in AssociationEndCardinality.entries) {
+                association("type2", "prop1$cardinality", "type1", cardinality)
             }
         }
 
@@ -198,12 +197,10 @@ class OrientDbSchemaInitializerTest {
     fun `two association with the same name to a single type`(): Unit = orientDb.withSession { oSession ->
         val model = model {
             entity("type1")
-            entity("type2") {
-                association("link1", "type1", AssociationEndCardinality._0_n)
-            }
-            entity("type3") {
-                association("link1", "type1", AssociationEndCardinality._0_n)
-            }
+            entity("type2")
+            entity("type3")
+            association("type2", "link1", "type1", AssociationEndCardinality._0_n)
+            association("type3", "link1", "type1", AssociationEndCardinality._0_n)
         }
 
         oSession.applySchema(model)
@@ -216,10 +213,9 @@ class OrientDbSchemaInitializerTest {
     fun `one-directional associations ignore cardinality`(): Unit = orientDb.withSession { oSession ->
         val model = model {
             entity("type1")
-            entity("type2") {
-                for (cardinality in AssociationEndCardinality.entries) {
-                    association("prop1$cardinality", "type1", cardinality)
-                }
+            entity("type2")
+            for (cardinality in AssociationEndCardinality.entries) {
+                association("type2", "prop1$cardinality", "type1", cardinality)
             }
         }
 

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
@@ -195,6 +195,24 @@ class OrientDbSchemaInitializerTest {
     }
 
     @Test
+    fun `two association with the same name to a single type`(): Unit = orientDb.withSession { oSession ->
+        val model = model {
+            entity("type1")
+            entity("type2") {
+                association("link1", "type1", AssociationEndCardinality._0_n)
+            }
+            entity("type3") {
+                association("link1", "type1", AssociationEndCardinality._0_n)
+            }
+        }
+
+        oSession.applySchema(model)
+
+        oSession.assertAssociationExists("type2", "type1", "link1", AssociationEndCardinality._0_n)
+        oSession.assertAssociationExists("type3", "type1", "link1", AssociationEndCardinality._0_n)
+    }
+
+    @Test
     fun `one-directional associations ignore cardinality`(): Unit = orientDb.withSession { oSession ->
         val model = model {
             entity("type1")

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
@@ -21,6 +21,8 @@ import com.orientechnologies.orient.core.metadata.schema.OType
 import com.orientechnologies.orient.core.record.ODirection
 import com.orientechnologies.orient.core.record.OVertex
 import jetbrains.exodus.entitystore.orientdb.ODatabaseProvider
+import jetbrains.exodus.entitystore.orientdb.OSchemaBuddy
+import jetbrains.exodus.entitystore.orientdb.OSchemaBuddyImpl
 import org.junit.Assert.*
 
 // assertions
@@ -145,9 +147,13 @@ internal fun model(initialize: ModelMetaDataImpl.() -> Unit): ModelMetaDataImpl 
     return model
 }
 
-internal fun oModel(databaseProvider: ODatabaseProvider, initialize: ModelMetaDataImpl.() -> Unit): OModelMetaData {
-    val model = OModelMetaData(databaseProvider)
-    model.initialize()
+internal fun oModel(
+    databaseProvider: ODatabaseProvider,
+    schemaBuddy: OSchemaBuddy = OSchemaBuddyImpl(databaseProvider, autoInitialize = false),
+    buildModel: ModelMetaDataImpl.() -> Unit
+): OModelMetaData {
+    val model = OModelMetaData(databaseProvider, schemaBuddy)
+    model.buildModel()
     return model
 }
 

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
@@ -211,9 +211,9 @@ internal fun EntityMetaDataImpl.setProperty(name: String, dataType: String) {
     this.propertiesMetaData = listOf(SimplePropertyMetaDataImpl(name, "Set", listOf(dataType)))
 }
 
-internal fun EntityMetaDataImpl.association(associationName: String, targetEntity: String, cardinality: AssociationEndCardinality) {
-    modelMetaData.addAssociation(
-        this.type,
+internal fun ModelMetaData.association(sourceEntity: String, associationName: String, targetEntity: String, cardinality: AssociationEndCardinality) {
+    addAssociation(
+        sourceEntity,
         targetEntity,
         AssociationType.Directed, // ingored
         associationName,


### PR DESCRIPTION
Here I wrapped up all the "main players" (ODataMigrator, OPersistentEntityStore, OModelMetadata) and made them work together.

Interesting stuff:
1. OPersistentEntityStore now has OSchemaBuddy to delegate the schema-related operations. There is OSchemaBuddyImpl on the entity-store package to make it self-sufficient. OPersistentTransaction.newEntity(...) still does not work if the schema has not been created in advance because OrientDB does not support schema changes in transactions. But when OrientDB supports schema changes in transactions, OPersistentTransaction.newEntity(...) will work without pre-created schema.
2. OModelMetadata implements OSchemaBuddy, so it can be passed to OPersistentEntityStore to delegate schema-related operations. So, OModelMetadata will handle all the schema-related operations.
3. There is `MigrateXodusToOrientDbSmokeTest`. One can see there how the whole process of data and schema migration looks like.