### PR TITLE
XD-988: Query transaction timeout

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
@@ -27,6 +27,7 @@ import jetbrains.exodus.entitystore.orientdb.iterate.link.OLinkIterableToEntityI
 import jetbrains.exodus.entitystore.orientdb.iterate.link.OLinkSortEntityIterable
 import jetbrains.exodus.entitystore.orientdb.iterate.link.OLinkToEntityIterable
 import jetbrains.exodus.entitystore.orientdb.iterate.property.OSequenceImpl
+import jetbrains.exodus.entitystore.orientdb.query.OQueryCancellingPolicy
 import jetbrains.exodus.env.Transaction
 
 class OStoreTransactionImpl(
@@ -36,7 +37,7 @@ class OStoreTransactionImpl(
     private val schemaBuddy: OSchemaBuddy
 ) : OStoreTransaction {
 
-    private var queryCancellingPolicy: QueryCancellingPolicy? = null
+    private var queryCancellingPolicy: OQueryCancellingPolicy? = null
 
     override val activeSession = session
 
@@ -54,7 +55,7 @@ class OStoreTransactionImpl(
     }
 
     override fun isReadonly(): Boolean {
-        if (!hasWriteOperations){
+        if (!hasWriteOperations) {
             hasWriteOperations = !isIdempotent
         }
         return !hasWriteOperations
@@ -286,6 +287,7 @@ class OStoreTransactionImpl(
     }
 
     override fun setQueryCancellingPolicy(policy: QueryCancellingPolicy?) {
+        require(policy is OQueryCancellingPolicy) { "Only OQueryCancellingPolicy is supported, but was ${policy?.javaClass?.simpleName}" }
         this.queryCancellingPolicy = policy
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OQueryEntityIterableBase.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OQueryEntityIterableBase.kt
@@ -209,7 +209,7 @@ abstract class OQueryEntityIterableBase(tx: StoreTransaction?) : EntityIterableB
         }
         val sourceQuery = query()
         val countQuery = OCountSelect(sourceQuery)
-        cachedSize = countQuery.count(otx.activeSession)
+        cachedSize = countQuery.count(otx)
         return cachedSize
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQuery.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQuery.kt
@@ -15,22 +15,10 @@
  */
 package jetbrains.exodus.entitystore.orientdb.query
 
-import com.orientechnologies.orient.core.db.ODatabaseSession
-import com.orientechnologies.orient.core.db.document.ODatabaseDocument
-import com.orientechnologies.orient.core.sql.executor.OResultSet
-
 /**
  * Implementations must be immutable.
  */
 interface OQuery : OSql {
 
     fun params(): List<Any> = emptyList<Any>()
-
-    fun execute(session: ODatabaseDocument? = null): OResultSet {
-        ODatabaseSession.getActiveSession()
-        val session = session ?: ODatabaseSession.getActiveSession()
-        val builder = StringBuilder()
-        sql(builder)
-        return session.query(builder.toString(), *params().toTypedArray())
-    }
 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryCancellingPolicy.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryCancellingPolicy.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright ${inceptionYear} - ${year} ${owner}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jetbrains.exodus.entitystore.orientdb.query
 
 import com.orientechnologies.common.concur.OTimeoutException

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryCancellingPolicy.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryCancellingPolicy.kt
@@ -1,0 +1,47 @@
+package jetbrains.exodus.entitystore.orientdb.query
+
+import com.orientechnologies.common.concur.OTimeoutException
+import jetbrains.exodus.entitystore.QueryCancellingPolicy
+
+class OQueryTimeoutException(message: String, source: Throwable) : RuntimeException(message, source) {
+
+    companion object {
+
+        fun <R> withTimeoutWrap(block: () -> R): R {
+            try {
+                return block()
+            } catch (e: OTimeoutException) {
+                throw OQueryTimeoutException("Query execution timed out", e)
+            }
+        }
+    }
+}
+
+interface OQueryCancellingPolicy : QueryCancellingPolicy {
+
+    companion object {
+
+        fun timeout(timeoutMillis: Long): OQueryCancellingPolicy = object : OQueryCancellingPolicy {
+            override val timeoutMillis: Long = timeoutMillis
+        }
+    }
+
+    /**
+     * Not applicable for OStoreTransaction.
+     */
+    override fun needToCancel(): Boolean {
+        return false
+    }
+
+    /**
+     * Not applicable for OStoreTransaction.
+     */
+    override fun doCancel() {}
+
+    /**
+     * Defines the maximum time in milliseconds for the query.
+     *
+     * The field is read once priory to each query execution.
+     */
+    val timeoutMillis: Long
+}

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryExecution.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryExecution.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright ${inceptionYear} - ${year} ${owner}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jetbrains.exodus.entitystore.orientdb.query
 
 import com.orientechnologies.common.concur.OTimeoutException

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryExecution.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryExecution.kt
@@ -1,0 +1,26 @@
+package jetbrains.exodus.entitystore.orientdb.query
+
+import com.orientechnologies.common.concur.OTimeoutException
+import com.orientechnologies.orient.core.sql.executor.OResultSet
+import jetbrains.exodus.entitystore.orientdb.OStoreTransaction
+
+object OQueryExecution {
+
+    fun execute(query: OQuery, tx: OStoreTransaction): OResultSet {
+        val session = tx.activeSession
+        val builder = StringBuilder()
+        query.sql(builder)
+
+        tx.queryCancellingPolicy?.let {
+            check(it is OQueryCancellingPolicy) { "Unsupported query cancelling policy: $it" }
+            val timeoutQuery = OQueryTimeout(it.timeoutMillis)
+            timeoutQuery.sql(builder)
+        }
+
+        return try {
+            session.query(builder.toString(), *query.params().toTypedArray())
+        } catch (timeoutException: OTimeoutException) {
+            throw OQueryTimeoutException("Query execution timed out", timeoutException)
+        }
+    }
+}

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryFunctions.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryFunctions.kt
@@ -15,7 +15,7 @@
  */
 package jetbrains.exodus.entitystore.orientdb.query
 
-import com.orientechnologies.orient.core.db.document.ODatabaseDocument
+import jetbrains.exodus.entitystore.orientdb.OStoreTransaction
 
 object OQueryFunctions {
 
@@ -84,7 +84,7 @@ class OCountSelect(
 
     override fun params() = source.params()
 
-    fun count(session: ODatabaseDocument): Long = execute(session).next().getProperty<Long>("count")
+    fun count(tx: OStoreTransaction): Long = OQueryExecution.execute(this, tx).next().getProperty<Long>("count")
 }
 
 class OFirstSelect(

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryTimeout.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryTimeout.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright ${inceptionYear} - ${year} ${owner}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jetbrains.exodus.entitystore.orientdb.query
 
 class OQueryTimeout(

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryTimeout.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryTimeout.kt
@@ -1,0 +1,10 @@
+package jetbrains.exodus.entitystore.orientdb.query
+
+class OQueryTimeout(
+    val timeoutMillis: Long
+) : OQuery {
+
+    override fun sql(builder: StringBuilder) {
+        builder.append(" TIMEOUT $timeoutMillis")
+    }
+}

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OTaskTrackerTestCase.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OTaskTrackerTestCase.kt
@@ -28,4 +28,11 @@ class OTaskTrackerTestCase(val orientDB: InMemoryOrientDB) {
     val board1 = orientDB.createBoard("board1")
     val board2 = orientDB.createBoard("board2")
     val board3 = orientDB.createBoard("board3")
+
+
+    fun createManyIssues(count: Int) {
+        for (i in 1..count) {
+            orientDB.createIssue("issue$i")
+        }
+    }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/agiles/153-3591/current?issue=XD-988

Scope of work:
# Added O-related cancalling policy with timeout only.
# Refactored query execution via OQueryExecution
# Added test