### PR TITLE
XD-1000: Express difference as AND NOT wherever possible

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OCondition.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OCondition.kt
@@ -76,6 +76,24 @@ sealed class OBiCondition(
 
 class OAndCondition(left: OCondition, right: OCondition) : OBiCondition("AND", left, right)
 class OOrCondition(left: OCondition, right: OCondition) : OBiCondition("OR", left, right)
+
+class OAndNotCondition(
+    val left: OCondition,
+    val right: OCondition
+) : OCondition {
+
+    override fun sql(builder: StringBuilder) {
+        builder.append("(")
+        left.sql(builder)
+        builder.append(" AND NOT (")
+        right.sql(builder)
+        builder.append("))")
+    }
+
+    override fun params() = left.params() + right.params()
+}
+
+// Others
 class ORangeCondition(
     val field: String,
     val minInclusive: Any,

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OConditions.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OConditions.kt
@@ -27,6 +27,12 @@ fun OCondition?.or(other: OCondition?): OCondition? {
     return OOrCondition(this, other)
 }
 
+fun OCondition?.andNot(other: OCondition?): OCondition? {
+    if (this == null) return other
+    if (other == null) return this
+    return OAndNotCondition(this, other)
+}
+
 fun equal(field: String, value: Any) = OEqualCondition(field, value)
 fun or(left: OCondition, right: OCondition) = OOrCondition(left, right)
 fun and(left: OCondition, right: OCondition) = OAndCondition(left, right)

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryFunctions.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryFunctions.kt
@@ -23,14 +23,12 @@ object OQueryFunctions {
         return when {
             left is OClassSelect && right is OClassSelect -> {
                 ensureSameClassName(left, right)
+                check(left.skip == null && right.skip == null) { "Skip can not be used for sub-query when intersect" }
+                check(left.limit == null && right.limit == null) { "Take can not be used for sub-query when intersect" }
+
                 val newCondition = left.condition.and(right.condition)
                 val newOrder = left.order.merge(right.order)
-
-                // narrow down the result set
-                val newSkip = left.skip.max(right.skip)
-                val newLimit = left.limit.min(right.limit)
-
-                OClassSelect(left.className, newCondition, newOrder, newSkip, newLimit)
+                OClassSelect(left.className, newCondition, newOrder)
             }
 
             else -> {
@@ -43,14 +41,12 @@ object OQueryFunctions {
         return when {
             left is OClassSelect && right is OClassSelect -> {
                 ensureSameClassName(left, right)
+                check(left.skip == null && right.skip == null) { "Skip can not be used for sub-query when union" }
+                check(left.limit == null && right.limit == null) { "Take can not be used for sub-query when union" }
+
                 val newCondition = left.condition.or(right.condition)
                 val newOrder = left.order.merge(right.order)
-
-                // shrink the result set
-                val newSkip = left.skip.min(right.skip)
-                val newLimit = left.limit.max(right.limit)
-
-                OClassSelect(left.className, newCondition, newOrder, newSkip, newLimit)
+                OClassSelect(left.className, newCondition, newOrder)
             }
 
             else -> {

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OEntityIterableBaseTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OEntityIterableBaseTest.kt
@@ -154,7 +154,34 @@ class OEntityIterableBaseTest : OTestMixin {
     }
 
     @Test
-    fun `should iterable minus`() {
+    fun `should iterable minus with properties`() {
+        // Given
+        val test = givenTestCase()
+        orientDb.withSession {
+            test.issue1.setProperty("complex", "true")
+            test.issue1.setProperty("blocked", "true")
+
+            test.issue2.setProperty("complex", "true")
+            test.issue2.setProperty("blocked", "false")
+
+            test.issue3.setProperty("complex", "false")
+            test.issue3.setProperty("blocked", "true")
+
+        }
+
+        // When
+        oTransactional { tx ->
+            val complexIssues = tx.find(Issues.CLASS, "complex", "true")
+            val blockedIssues = tx.find(Issues.CLASS, "blocked", "true")
+            val complexUnblockedIssues = complexIssues.minus(blockedIssues)
+
+            // Then
+            assertNamesExactly(complexUnblockedIssues, "issue2")
+        }
+    }
+
+    @Test
+    fun `should iterable minus with links`() {
         // Given
         val test = givenTestCase()
 

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OEntityIterableBaseTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OEntityIterableBaseTest.kt
@@ -23,6 +23,7 @@ import jetbrains.exodus.entitystore.orientdb.testutil.OTestMixin
 import jetbrains.exodus.entitystore.orientdb.testutil.addIssueToBoard
 import jetbrains.exodus.entitystore.orientdb.testutil.name
 import jetbrains.exodus.testutil.eventually
+import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 
@@ -251,7 +252,8 @@ class OEntityIterableBaseTest : OTestMixin {
             val issues = skippedIssues.intersect(limitIssues)
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue2")
+            val exception = Assert.assertThrows(IllegalStateException::class.java) { issues.toList() }
+            assertThat(exception.message).contains("Skip can not be used for sub-query")
         }
     }
 
@@ -267,7 +269,8 @@ class OEntityIterableBaseTest : OTestMixin {
             val issues = skippedIssues.union(limitIssues)
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue2", "issue3")
+            val exception = Assert.assertThrows(IllegalStateException::class.java) { issues.toList() }
+            assertThat(exception.message).contains("Skip can not be used for sub-query")
         }
     }
 


### PR DESCRIPTION
[XD-1000](https://youtrack.jetbrains.com/issue/XD-1000) [Query] Express difference as AND NOT wherever possible

Example of resulting SQL:

"Query: SELECT FROM Issue WHERE (complex = ? AND NOT (blocked = ?)), params: [true, true]"