### PR TITLE
Make links unique with the help of indices

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
@@ -272,6 +272,14 @@ open class OVertexEntity(private var vertex: OVertex, private val store: Persist
         /*
         We check for duplicates only if there is an appropriate index for it.
         Without an index, performance degradation will be catastrophic.
+
+        You may ask why not to throw an exception if there is no an index?
+        Well, we have the data migration process. During this process:
+        1. We do not have any indices
+        2. Skipping this findEdge(...) call is exactly what we want from the performance point of view.
+        3. We avoid duplicates explicitly.
+        Well, during the data migration process, there are no any indices and
+        skipping this findEdge(...) call is exactly what we need.
          */
         val currentEdge: OEdge? = if (edgeClass.areIndexed(OEdge.DIRECTION_IN, OEdge.DIRECTION_OUT)) {
             findEdge(edgeClassName, target.id)

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
@@ -44,7 +44,7 @@ open class OVertexEntity(private var vertex: OVertex, private val store: Persist
     companion object : KLogging() {
         const val BINARY_BLOB_CLASS_NAME: String = "BinaryBlob"
         const val DATA_PROPERTY_NAME = "data"
-        const val EDGE_CLASS_SUFFIX = "\$link"
+        const val EDGE_CLASS_SUFFIX = "_link"
         private const val BLOB_SIZE_PROPERTY_NAME_SUFFIX = "_blob_size"
         private const val STRING_BLOB_HASH_PROPERTY_NAME_SUFFIX = "_string_blob_hash"
         fun blobSizeProperty(propertyName: String) = "\$$propertyName$BLOB_SIZE_PROPERTY_NAME_SUFFIX"

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/IndicesCreator.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/IndicesCreator.kt
@@ -56,6 +56,7 @@ internal class IndicesCreator(
             }
         } catch (e: Throwable) {
             logger.flush()
+            throw e
         } finally {
             logger.flush()
         }

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
@@ -19,6 +19,7 @@ import com.orientechnologies.orient.core.metadata.schema.OProperty
 import com.orientechnologies.orient.core.metadata.schema.OType
 import com.orientechnologies.orient.core.record.ODirection
 import com.orientechnologies.orient.core.record.OVertex
+import com.orientechnologies.orient.core.storage.ORecordDuplicatedException
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.CLASS_ID_CUSTOM_PROPERTY_NAME
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.LOCAL_ENTITY_ID_PROPERTY_NAME
@@ -337,20 +338,22 @@ class OrientDbSchemaInitializerTest {
             oSession.applyIndices(indices)
         }
 
-        orientDb.withTxSession { oSession ->
-            val oClass = oSession.getClass("type1")!!
-            val v1 = oSession.newVertex(oClass)
-            oSession.setLocalEntityId("type1", v1)
-            v1.requireLocalEntityId()
-            v1.setProperty("prop1", 3)
-            v1.setProperty("prop2", 4)
-            v1.save<OVertex>()
+        assertFailsWith<ORecordDuplicatedException> {
+            orientDb.withTxSession { oSession ->
+                val oClass = oSession.getClass("type1")!!
+                val v1 = oSession.newVertex(oClass)
+                oSession.setLocalEntityId("type1", v1)
+                v1.requireLocalEntityId()
+                v1.setProperty("prop1", 3)
+                v1.setProperty("prop2", 4)
+                v1.save<OVertex>()
 
-            val v2 = oSession.newVertex(oClass)
-            oSession.setLocalEntityId("type1", v2)
-            v2.setProperty("prop1", 3L)
-            v2.setProperty("prop2", 4L)
-            v2.save<OVertex>()
+                val v2 = oSession.newVertex(oClass)
+                oSession.setLocalEntityId("type1", v2)
+                v2.setProperty("prop1", 3L)
+                v2.setProperty("prop2", 4L)
+                v2.save<OVertex>()
+            }
         }
     }
 
@@ -434,6 +437,7 @@ class OrientDbSchemaInitializerTest {
             assertEquals(1, links.count())
         }
     }
+
     @Test
     fun `index for every simple property if required`() = orientDb.provider.acquireSession().use { oSession ->
         val model = model {

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
@@ -383,11 +383,10 @@ class OrientDbSchemaInitializerTest {
             v2.setProperty("prop1", 2)
             v2.save<OVertex>()
 
-            v1.addEdge(v2, edgeClassName)
-            v1.addEdge(v2, edgeClassName)
-
-            v1.save<OVertex>()
-            v2.save<OVertex>()
+            val entity1 = OVertexEntity(v1, orientDb.store)
+            val entity2 = OVertexEntity(v2, orientDb.store)
+            entity1.addLink("ass1", entity2)
+            entity1.addLink("ass1", entity2)
         }
 
         orientDb.withTxSession { oSession ->
@@ -412,25 +411,28 @@ class OrientDbSchemaInitializerTest {
         }
 
         val edgeClassName = edgeClassName("ass1")
-        assertFailsWith<ORecordDuplicatedException> {
-            orientDb.withTxSession { oSession ->
-                val oClass = oSession.getClass("type1")!!
-                val v1 = oSession.newVertex(oClass)
-                oSession.setLocalEntityId("type1", v1)
-                v1.setProperty("prop1", 1)
-                v1.save<OVertex>()
+        orientDb.withTxSession { oSession ->
+            val oClass = oSession.getClass("type1")!!
+            val v1 = oSession.newVertex(oClass)
+            oSession.setLocalEntityId("type1", v1)
+            v1.setProperty("prop1", 1)
+            v1.save<OVertex>()
 
-                val v2 = oSession.newVertex(oClass)
-                oSession.setLocalEntityId("type1", v2)
-                v2.setProperty("prop1", 2)
-                v2.save<OVertex>()
+            val v2 = oSession.newVertex(oClass)
+            oSession.setLocalEntityId("type1", v2)
+            v2.setProperty("prop1", 2)
+            v2.save<OVertex>()
 
-                v1.addEdge(v2, edgeClassName)
-                v1.addEdge(v2, edgeClassName)
+            val entity1 = OVertexEntity(v1, orientDb.store)
+            val entity2 = OVertexEntity(v2, orientDb.store)
+            entity1.addLink("ass1", entity2)
+            entity1.addLink("ass1", entity2)
+        }
 
-                v1.save<OVertex>()
-                v2.save<OVertex>()
-            }
+        orientDb.withTxSession { oSession ->
+            val v1 = oSession.browseClass("type1").map { it.toVertex()!! }.first { it.getProperty<Int>("prop1") == 1 }
+            val links: MutableIterable<OVertex> = v1.getVertices(ODirection.OUT, edgeClassName)
+            assertEquals(1, links.count())
         }
     }
 

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
@@ -17,12 +17,17 @@ package jetbrains.exodus.query.metadata
 
 import com.orientechnologies.orient.core.metadata.schema.OProperty
 import com.orientechnologies.orient.core.metadata.schema.OType
+import com.orientechnologies.orient.core.record.ODirection
+import com.orientechnologies.orient.core.record.OVertex
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.CLASS_ID_CUSTOM_PROPERTY_NAME
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.LOCAL_ENTITY_ID_PROPERTY_NAME
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.STRING_BLOB_CLASS_NAME
+import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.edgeClassName
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.localEntityIdSequenceName
 import jetbrains.exodus.entitystore.orientdb.requireClassId
+import jetbrains.exodus.entitystore.orientdb.requireLocalEntityId
+import jetbrains.exodus.entitystore.orientdb.setLocalEntityId
 import jetbrains.exodus.entitystore.orientdb.testutil.InMemoryOrientDB
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -135,7 +140,7 @@ class OrientDbSchemaInitializerTest {
         val blobDataProp = blobClass.getProperty(OVertexEntity.DATA_PROPERTY_NAME)!!
         assertEquals(OType.BINARY, blobDataProp.type)
 
-        val strBlobClass = oSession.getClass(OVertexEntity.STRING_BLOB_CLASS_NAME)!!
+        val strBlobClass = oSession.getClass(STRING_BLOB_CLASS_NAME)!!
         val strBlobDataProp = strBlobClass.getProperty(OVertexEntity.DATA_PROPERTY_NAME)!!
         assertEquals(OType.BINARY, strBlobDataProp.type)
 
@@ -147,7 +152,7 @@ class OrientDbSchemaInitializerTest {
 
         val strBlobProp = entity.getProperty("strBlob1")!!
         assertEquals(OType.LINK, strBlobProp.type)
-        assertEquals(OVertexEntity.STRING_BLOB_CLASS_NAME, strBlobProp.linkedClass!!.name)
+        assertEquals(STRING_BLOB_CLASS_NAME, strBlobProp.linkedClass!!.name)
     }
 
     @Test
@@ -317,6 +322,118 @@ class OrientDbSchemaInitializerTest {
         }
     }
 
+    @Test
+    fun `unique index forbids to create vertices with the same property value`() {
+        val model = model {
+            entity("type1") {
+                property("prop1", "int")
+                property("prop2", "long")
+                index("prop1")
+            }
+        }
+
+        orientDb.withSession { oSession ->
+            val indices = oSession.applySchema(model, indexForEverySimpleProperty = false)
+            oSession.applyIndices(indices)
+        }
+
+        orientDb.withTxSession { oSession ->
+            val oClass = oSession.getClass("type1")!!
+            val v1 = oSession.newVertex(oClass)
+            oSession.setLocalEntityId("type1", v1)
+            v1.requireLocalEntityId()
+            v1.setProperty("prop1", 3)
+            v1.setProperty("prop2", 4)
+            v1.save<OVertex>()
+
+            val v2 = oSession.newVertex(oClass)
+            oSession.setLocalEntityId("type1", v2)
+            v2.setProperty("prop1", 3L)
+            v2.setProperty("prop2", 4L)
+            v2.save<OVertex>()
+        }
+    }
+
+    @Test
+    fun `link duplicates are allowed if there is no indices`() {
+        val model = model {
+            entity("type1") {
+                property("prop1", "int")
+            }
+            association("type1", "ass1", "type1", AssociationEndCardinality._0_n)
+        }
+
+        orientDb.withSession { oSession ->
+            oSession.applySchema(model, indexForEverySimpleProperty = false)
+        }
+
+        val edgeClassName = edgeClassName("ass1")
+        orientDb.withTxSession { oSession ->
+            val oClass = oSession.getClass("type1")!!
+            val v1 = oSession.newVertex(oClass)
+            oSession.setLocalEntityId("type1", v1)
+            v1.setProperty("prop1", 1)
+            v1.save<OVertex>()
+
+            val v2 = oSession.newVertex(oClass)
+            oSession.setLocalEntityId("type1", v2)
+            v2.setProperty("prop1", 2)
+            v2.save<OVertex>()
+
+            v1.addLightWeightEdge(v2, edgeClassName)
+            v1.addLightWeightEdge(v2, edgeClassName)
+
+            v1.save<OVertex>()
+            v2.save<OVertex>()
+        }
+
+        orientDb.withTxSession { oSession ->
+            val v1 = oSession.browseClass("type1").map { it.toVertex()!! }.first { it.getProperty<Int>("prop1") == 1 }
+            val links: MutableIterable<OVertex> = v1.getVertices(ODirection.OUT, edgeClassName)
+            assertEquals(2, links.count())
+        }
+    }
+
+    @Test
+    fun `link duplicates are forbidden if indices are created`() {
+        val model = model {
+            entity("type1") {
+                property("prop1", "int")
+            }
+            association("type1", "ass1", "type1", AssociationEndCardinality._0_n)
+        }
+
+        orientDb.withSession { oSession ->
+            val indices = oSession.applySchema(model, indexForEverySimpleProperty = false)
+            oSession.applyIndices(indices)
+        }
+
+        val edgeClassName = edgeClassName("ass1")
+        orientDb.withTxSession { oSession ->
+            val oClass = oSession.getClass("type1")!!
+            val v1 = oSession.newVertex(oClass)
+            oSession.setLocalEntityId("type1", v1)
+            v1.setProperty("prop1", 1)
+            v1.save<OVertex>()
+
+            val v2 = oSession.newVertex(oClass)
+            oSession.setLocalEntityId("type1", v2)
+            v2.setProperty("prop1", 2)
+            v2.save<OVertex>()
+
+            v1.addLightWeightEdge(v2, edgeClassName)
+            v1.addLightWeightEdge(v2, edgeClassName)
+
+            v1.save<OVertex>()
+            v2.save<OVertex>()
+        }
+
+        orientDb.withTxSession { oSession ->
+            val v1 = oSession.browseClass("type1").map { it.toVertex()!! }.first { it.getProperty<Int>("prop1") == 1 }
+            val links: MutableIterable<OVertex> = v1.getVertices(ODirection.OUT, edgeClassName)
+            assertEquals(1, links.count())
+        }
+    }
     @Test
     fun `index for every simple property if required`() = orientDb.provider.acquireSession().use { oSession ->
         val model = model {

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
@@ -383,8 +383,8 @@ class OrientDbSchemaInitializerTest {
             v2.setProperty("prop1", 2)
             v2.save<OVertex>()
 
-            v1.addLightWeightEdge(v2, edgeClassName)
-            v1.addLightWeightEdge(v2, edgeClassName)
+            v1.addEdge(v2, edgeClassName)
+            v1.addEdge(v2, edgeClassName)
 
             v1.save<OVertex>()
             v2.save<OVertex>()
@@ -412,29 +412,25 @@ class OrientDbSchemaInitializerTest {
         }
 
         val edgeClassName = edgeClassName("ass1")
-        orientDb.withTxSession { oSession ->
-            val oClass = oSession.getClass("type1")!!
-            val v1 = oSession.newVertex(oClass)
-            oSession.setLocalEntityId("type1", v1)
-            v1.setProperty("prop1", 1)
-            v1.save<OVertex>()
+        assertFailsWith<ORecordDuplicatedException> {
+            orientDb.withTxSession { oSession ->
+                val oClass = oSession.getClass("type1")!!
+                val v1 = oSession.newVertex(oClass)
+                oSession.setLocalEntityId("type1", v1)
+                v1.setProperty("prop1", 1)
+                v1.save<OVertex>()
 
-            val v2 = oSession.newVertex(oClass)
-            oSession.setLocalEntityId("type1", v2)
-            v2.setProperty("prop1", 2)
-            v2.save<OVertex>()
+                val v2 = oSession.newVertex(oClass)
+                oSession.setLocalEntityId("type1", v2)
+                v2.setProperty("prop1", 2)
+                v2.save<OVertex>()
 
-            v1.addLightWeightEdge(v2, edgeClassName)
-            v1.addLightWeightEdge(v2, edgeClassName)
+                v1.addEdge(v2, edgeClassName)
+                v1.addEdge(v2, edgeClassName)
 
-            v1.save<OVertex>()
-            v2.save<OVertex>()
-        }
-
-        orientDb.withTxSession { oSession ->
-            val v1 = oSession.browseClass("type1").map { it.toVertex()!! }.first { it.getProperty<Int>("prop1") == 1 }
-            val links: MutableIterable<OVertex> = v1.getVertices(ODirection.OUT, edgeClassName)
-            assertEquals(1, links.count())
+                v1.save<OVertex>()
+                v2.save<OVertex>()
+            }
         }
     }
 

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
@@ -411,7 +411,8 @@ class OrientDbSchemaInitializerTest {
         }
 
         val edgeClassName = edgeClassName("ass1")
-        orientDb.withTxSession { oSession ->
+        // trying to add the same edge in a single transaction
+        val (id1, id2) = orientDb.withTxSession { oSession ->
             val oClass = oSession.getClass("type1")!!
             val v1 = oSession.newVertex(oClass)
             oSession.setLocalEntityId("type1", v1)
@@ -426,6 +427,16 @@ class OrientDbSchemaInitializerTest {
             val entity1 = OVertexEntity(v1, orientDb.store)
             val entity2 = OVertexEntity(v2, orientDb.store)
             entity1.addLink("ass1", entity2)
+            entity1.addLink("ass1", entity2)
+            Pair(v1.identity, v2.identity)
+        }
+
+        // trying to add the same edge in another transaction
+        orientDb.withTxSession { oSession ->
+            val v1 = oSession.getRecord<OVertex>(id1)
+            val v2 = oSession.getRecord<OVertex>(id2)
+            val entity1 = OVertexEntity(v1, orientDb.store)
+            val entity2 = OVertexEntity(v2, orientDb.store)
             entity1.addLink("ass1", entity2)
         }
 

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
@@ -194,6 +194,7 @@ internal fun EntityMetaDataImpl.index(vararg fieldNames: String) {
 }
 
 internal fun EntityMetaDataImpl.property(name: String, typeName: String, required: Boolean = false) {
+    // regardless of the name, this setter actually ADDS new properties to its internal collection
     this.propertiesMetaData = listOf(SimplePropertyMetaDataImpl(name, typeName))
     if (required) {
         requiredProperties = requiredProperties + setOf(name)


### PR DESCRIPTION
The links duplication problem is solved now in the following way: 
1. On adding a link, we check if there is already the same link. If there is, we just silently skip new one, if there is no, we add the new one. 
2. We do this checking only if there is an appropriate index for the edge class (for the in and out edges). If there is no an index, we do not check for link duplicates.

Check out the new tests to see how it works.