### PR TITLE
Minor UX improvements for data migrator

### DIFF
--- a/query/build.gradle.kts
+++ b/query/build.gradle.kts
@@ -37,6 +37,7 @@ tasks {
             "orientPassword" to (project.findProperty("orientPassword")),
 
             "validateDataAfterMigration" to (project.findProperty("validateDataAfterMigration")),
+            "entitiesPerTransaction" to (project.findProperty("entitiesPerTransaction")),
         )
     }
 }

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/CountingOTransaction.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/CountingOTransaction.kt
@@ -38,10 +38,14 @@ class CountingOTransaction(
     private var counter = 0
     private lateinit var txn : StoreTransaction
 
+    var transactionsCommited: Long = 0
+        private set
+
     fun increment() {
         counter++
         if (counter == commitEvery) {
             txn.flush()
+            transactionsCommited++
             counter = 0
         }
     }
@@ -51,7 +55,10 @@ class CountingOTransaction(
     }
 
     fun commit() {
-        txn.commit()
+        if (!txn.isFinished) {
+            txn.commit()
+            transactionsCommited++
+        }
     }
 
     fun rollback() {

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrient.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrient.kt
@@ -30,6 +30,7 @@ fun main() {
     val orientPasswordStr = System.getProperty("orientPassword")
 
     val validateDataAfterMigrationStr = System.getProperty("validateDataAfterMigration")
+    val entitiesPerTransactionStr = System.getProperty("entitiesPerTransaction")
     println("""
             Provided params:
                 xodusDatabaseDirectory: $xodusDatabaseDirectory
@@ -44,6 +45,7 @@ fun main() {
                 orientPassword: $orientPasswordStr
                 
                 validateDataAfterMigration: $validateDataAfterMigrationStr
+                entitiesPerTransaction: $entitiesPerTransactionStr
         """.trimIndent())
 
     val xodusCypherIV = xodusCipherIVStr.toLongOrNull() ?: 0L
@@ -63,6 +65,7 @@ fun main() {
     val orientPassword = if (!orientPasswordStr.isNullOrBlank()) orientPasswordStr else "password"
 
     val validateDataAfterMigration = validateDataAfterMigrationStr?.toBooleanStrictOrNull() ?: true
+    val entitiesPerTransaction = validateDataAfterMigrationStr?.toIntOrNull() ?: 100
 
     println("""
             Effective params:
@@ -78,6 +81,7 @@ fun main() {
                 orientPassword: $orientPassword
                
                 validateDataAfterMigration: $validateDataAfterMigration
+                entitiesPerTransaction: $entitiesPerTransaction
         """.trimIndent())
 
     val launcher = XodusToOrientDataMigratorLauncher(
@@ -94,7 +98,8 @@ fun main() {
             username = orientUsername,
             password = orientPassword
         ),
-        validateDataAfterMigration = validateDataAfterMigration
+        validateDataAfterMigration = validateDataAfterMigration,
+        entitiesPerTransaction = entitiesPerTransaction
     )
     launcher.migrate()
 }

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigrator.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigrator.kt
@@ -54,6 +54,7 @@ data class XodusToOrientMigrationStats(
     val entities: Long,
     val properties: Long,
     val blobs: Long,
+    val copyEntitiesPropertiesAndBlobsTransactions: Long,
     val copyEntitiesPropertiesAndBlobsDuration: Duration,
     val createEntitiesDuration: Duration,
     val copyPropertiesDuration: Duration,
@@ -64,6 +65,7 @@ data class XodusToOrientMigrationStats(
     val createEdgeClassesDuration: Duration,
     val processedLinks: Long,
     val copiedLinks: Long,
+    val copyLinksTransactions: Long,
     val copyLinksTotalDuration: Duration,
     val copyLinksDuration: Duration,
     val commitLinksDuration: Duration,
@@ -105,6 +107,9 @@ internal class XodusToOrientDataMigrator(
     private var copyLinksDuration = Duration.ZERO
     private var commitLinksDuration = Duration.ZERO
 
+    private var copyEntitiesPropertiesAndBlobsTransactions = 0L
+    private var copyLinksTransactions = 0L
+
     fun migrate(): XodusToOrientMigrationStats {
         log.info { "Starting Xodus -> OrientDB data migration" }
         val createVertexClassesDuration = measureTime {
@@ -127,6 +132,7 @@ internal class XodusToOrientDataMigrator(
             entities = totalEntities,
             properties = totalProperties,
             blobs = totalBlobs,
+            copyEntitiesPropertiesAndBlobsTransactions = copyEntitiesPropertiesAndBlobsTransactions,
             copyEntitiesPropertiesAndBlobsDuration = copyPropertiesAndBlobsDuration,
             createEntitiesDuration = createEntitiesDuration,
             copyPropertiesDuration = copyPropertiesDuration,
@@ -138,6 +144,7 @@ internal class XodusToOrientDataMigrator(
 
             processedLinks = totalLinksProcessed,
             copiedLinks = totalLinksCopied,
+            copyLinksTransactions = copyLinksTransactions,
             copyLinksTotalDuration = copyLinksTotalDuration,
             copyLinksDuration = copyLinksDuration,
             commitLinksDuration = commitLinksDuration,
@@ -249,6 +256,8 @@ internal class XodusToOrientDataMigrator(
                     totalProperties += properties
                     totalBlobs += blobs
                 }
+                countingTx.commit()
+                copyEntitiesPropertiesAndBlobsTransactions = countingTx.transactionsCommited
                 log.info { "Entities have been copied. Entity types: ${entityTypes.size}, entities copied: $totalEntities, properties copied: $totalProperties, blobs copied: $totalBlobs" }
             }
         }
@@ -322,6 +331,8 @@ internal class XodusToOrientDataMigrator(
                     totalLinksProcessed += linksProcessed
                     totalLinksCopied += linksCopied
                 }
+                countingTx.commit()
+                copyLinksTransactions = countingTx.transactionsCommited
                 log.info { "Links have been copied. Entity types: ${entityTypes.size}, entities processed: $totalEntities, links processed: $totalLinksProcessed, links copied: $totalLinksCopied" }
             }
         }

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigratorLauncher.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigratorLauncher.kt
@@ -49,6 +49,7 @@ class XodusToOrientDataMigratorLauncher(
     val orient: MigrateToOrientConfig,
     val xodus: MigrateFromXodusConfig,
     val validateDataAfterMigration: Boolean,
+    val entitiesPerTransaction: Int
 ) {
     fun migrate() {
         // 1. Where we migrate the data to
@@ -109,7 +110,7 @@ class XodusToOrientDataMigratorLauncher(
 
             // 3. Migrate the data
             val (migrateDataStats, migrateDataDuration) = measureTimedValue {
-                migrateDataFromXodusToOrientDb(xEntityStore, oEntityStore)
+                migrateDataFromXodusToOrientDb(xEntityStore, oEntityStore, entitiesPerTransaction)
             }
             schemaBuddy.initialize()
 

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigratorLauncher.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigratorLauncher.kt
@@ -132,20 +132,24 @@ class XodusToOrientDataMigratorLauncher(
                         entities: $entities
                         properties: $properties
                         blobs: $blobs
+                        transactions: $copyEntitiesPropertiesAndBlobsTransactions
                         copy entities properties and blobs duration: $copyEntitiesPropertiesAndBlobsDuration ${percent(copyEntitiesPropertiesAndBlobsDuration / migrateDataDuration)}
                             create entities duration: $createEntitiesDuration ${percent(createEntitiesDuration / copyEntitiesPropertiesAndBlobsDuration)}
                             copy properties duration: $copyPropertiesDuration ${percent(copyPropertiesDuration / copyEntitiesPropertiesAndBlobsDuration)}
                             copy blobs duration: $copyBlobsDuration ${percent(copyBlobsDuration / copyEntitiesPropertiesAndBlobsDuration)}
                             commits duration: $commitEntitiesPropertiesAndBlobsDuration ${percent(commitEntitiesPropertiesAndBlobsDuration / copyEntitiesPropertiesAndBlobsDuration)}
-                        
+                            single commit duration: ${commitEntitiesPropertiesAndBlobsDuration / copyEntitiesPropertiesAndBlobsTransactions.toInt()}
+
                         edge classes: $edgeClasses
                         create edge classes duration: $createEdgeClassesDuration ${percent(createEdgeClassesDuration / migrateDataDuration)}
                         
                         processed links: $processedLinks
                         copied links: $copiedLinks
+                        transactions: $copyLinksTransactions
                         copy links total duration: $copyLinksTotalDuration ${percent(copyLinksTotalDuration / migrateDataDuration)}
                             copy links duration: $copyLinksDuration ${percent(copyLinksDuration / copyLinksTotalDuration)}
                             commits duration: $commitLinksDuration ${percent(commitLinksDuration / copyLinksTotalDuration)}
+                            single commit duration: ${commitLinksDuration / copyLinksTransactions.toInt()}
             """.trimIndent()
                 }
             }

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
@@ -16,7 +16,6 @@
 package jetbrains.exodus.query.metadata
 
 import com.orientechnologies.orient.core.db.ODatabaseType
-import org.junit.Ignore
 import org.junit.Test
 
 class MigrateYourDatabaseTest {

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
@@ -17,6 +17,7 @@ package jetbrains.exodus.query.metadata
 
 import com.orientechnologies.orient.core.db.ODatabaseType
 import org.junit.Test
+import kotlin.test.Ignore
 
 class MigrateYourDatabaseTest {
 

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
@@ -49,7 +49,8 @@ class MigrateYourDatabaseTest {
                 cipherKey = yourCipherKey,
                 cipherIV = yourCipherIV
             ),
-            validateDataAfterMigration = true
+            validateDataAfterMigration = true,
+            entitiesPerTransaction = 100
         )
         launcher.migrate()
     }


### PR DESCRIPTION
A couple of UX improvements for the data migrator:
1. Now it is possible to pass `entityPerTransaction` param via the command line
2. Now we count comited transactions during the data migration