### PR TITLE
XD-1065: Add depth for sql query building

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OQueryEntityIterableBase.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OQueryEntityIterableBase.kt
@@ -15,14 +15,7 @@
  */
 package jetbrains.exodus.entitystore.orientdb.iterate
 
-import jetbrains.exodus.entitystore.Entity
-import jetbrains.exodus.entitystore.EntityIterable
-import jetbrains.exodus.entitystore.EntityIterableHandle
-import jetbrains.exodus.entitystore.EntityIterator
-import jetbrains.exodus.entitystore.StoreTransaction
-import jetbrains.exodus.entitystore.asOQueryIterable
-import jetbrains.exodus.entitystore.asOStore
-import jetbrains.exodus.entitystore.asOStoreTransaction
+import jetbrains.exodus.entitystore.*
 import jetbrains.exodus.entitystore.iterate.EntityIdSet
 import jetbrains.exodus.entitystore.iterate.EntityIterableBase
 import jetbrains.exodus.entitystore.orientdb.OEntityIterableHandle
@@ -35,11 +28,7 @@ import jetbrains.exodus.entitystore.orientdb.iterate.binop.OUnionEntityIterable
 import jetbrains.exodus.entitystore.orientdb.iterate.link.OLinkIterableToEntityIterableFiltered
 import jetbrains.exodus.entitystore.orientdb.iterate.link.OLinkSelectEntityIterable
 import jetbrains.exodus.entitystore.orientdb.iterate.link.OSingleEntityIterable
-import jetbrains.exodus.entitystore.orientdb.query.OCountSelect
-import jetbrains.exodus.entitystore.orientdb.query.OFirstSelect
-import jetbrains.exodus.entitystore.orientdb.query.OLastSelect
-import jetbrains.exodus.entitystore.orientdb.query.OQuery
-import jetbrains.exodus.entitystore.orientdb.query.OSelect
+import jetbrains.exodus.entitystore.orientdb.query.*
 import jetbrains.exodus.entitystore.util.unsupported
 import java.util.concurrent.Executor
 
@@ -89,7 +78,7 @@ abstract class OQueryEntityIterableBase(tx: StoreTransaction?) : EntityIterableB
     }
 
     override fun getHandleImpl(): EntityIterableHandle {
-        val builder = StringBuilder()
+        val builder = SqlBuilder()
         query().sql(builder)
         return OEntityIterableHandle(builder.toString())
     }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OCondition.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OCondition.kt
@@ -25,7 +25,7 @@ class OEqualCondition(
     val value: Any,
 ) : OCondition {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append(field).append(" = ?")
     }
 
@@ -37,7 +37,7 @@ class OContainsCondition(
     val value: String,
 ) : OCondition {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append(field).append(" containsText ?")
     }
 
@@ -49,7 +49,7 @@ class OStartsWithCondition(
     val value: String,
 ) : OCondition {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append(field).append(" like ?")
     }
 
@@ -63,11 +63,11 @@ sealed class OBiCondition(
     val right: OCondition
 ) : OCondition {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append("(")
-        left.sql(builder)
+        left.sql(builder.deepen())
         builder.append(" ").append(operation).append(" ")
-        right.sql(builder)
+        right.sql(builder.deepen())
         builder.append(")")
     }
 
@@ -82,11 +82,11 @@ class OAndNotCondition(
     val right: OCondition
 ) : OCondition {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append("(")
-        left.sql(builder)
+        left.sql(builder.deepen())
         builder.append(" AND NOT (")
-        right.sql(builder)
+        right.sql(builder.deepen())
         builder.append("))")
     }
 
@@ -101,7 +101,7 @@ class ORangeCondition(
 ) : OCondition {
 
     // https://orientdb.com/docs/3.2.x/sql/SQL-Where.html#between
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append("(").append(field).append(" between ? and ?)")
     }
 
@@ -112,7 +112,7 @@ class OEdgeExistsCondition(
     val edge: String
 ) : OCondition {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append("outE('").append(edge).append("').size() > 0")
     }
 }
@@ -121,7 +121,7 @@ class OFieldExistsCondition(
     val field: String
 ) : OCondition {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append("not(").append(field).append(" is null)")
     }
 }
@@ -131,7 +131,7 @@ class OInstanceOfCondition(
     val invert: Boolean
 ) : OCondition {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         if (invert){
             builder.append("NOT ")
         }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OLimit.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OLimit.kt
@@ -24,7 +24,7 @@ class OLimitValue(
     val value: Int
 ) : OLimit {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append(value)
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OOrder.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OOrder.kt
@@ -34,7 +34,7 @@ class OOrderByFields(
         )
     )
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         var count = 0
 
         for ((field, ascending) in items) {

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQuery.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQuery.kt
@@ -20,5 +20,5 @@ package jetbrains.exodus.entitystore.orientdb.query
  */
 interface OQuery : OSql {
 
-    fun params(): List<Any> = emptyList<Any>()
+    fun params(): List<Any> = emptyList()
 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryExecution.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryExecution.kt
@@ -22,7 +22,7 @@ import mu.KLogging
 object OQueryExecution : KLogging() {
 
     fun execute(query: OQuery, tx: OStoreTransaction): OResultSet {
-        val builder = StringBuilder()
+        val builder = SqlBuilder()
         query.sql(builder)
         tx.queryCancellingPolicy?.let {
             check(it is OQueryCancellingPolicy) { "Unsupported query cancelling policy: $it" }
@@ -32,6 +32,12 @@ object OQueryExecution : KLogging() {
 
         val session = tx.activeSession
         val resultSet = session.query(builder.toString(), *query.params().toTypedArray())
+
+        // Log execution plan
+        // ToDo: add System param to enable/disable logging of execution plan
+        val executionPlan = resultSet.executionPlan.get().prettyPrint(10, 8)
+        logger.info { "Query: $builder, params: ${query.params()}, \n execution plan:\n  $executionPlan, \n stats: ${resultSet.queryStats}" }
+
         return resultSet
     }
 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryFunctions.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryFunctions.kt
@@ -86,24 +86,25 @@ class OCountSelect(
     val source: OSelect,
 ) : OQuery {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append("SELECT count(*) as count FROM (")
-        source.sql(builder)
+        source.sql(builder.deepen())
         builder.append(")")
     }
 
     override fun params() = source.params()
 
-    fun count(tx: OStoreTransaction): Long = OQueryExecution.execute(this, tx).next().getProperty<Long>("count")
+    fun count(tx: OStoreTransaction): Long = OQueryExecution.execute(this, tx).next().getProperty("count")
 }
 
 class OFirstSelect(
     val source: OSelect,
 ) : OQuery {
 
-    override fun sql(builder: StringBuilder) {
-        builder.append("SELECT expand(first(\$a)) LET \$a = (")
-        source.sql(builder)
+    override fun sql(builder: SqlBuilder) {
+        val depth = builder.depth
+        builder.append("SELECT expand(first(\$a${depth})) LET \$a${depth} = (")
+        source.sql(builder.deepen())
         builder.append(")")
     }
 
@@ -115,9 +116,10 @@ class OLastSelect(
     val source: OSelect,
 ) : OQuery {
 
-    override fun sql(builder: StringBuilder) {
-        builder.append("SELECT expand(last(\$a)) LET \$a = (")
-        source.sql(builder)
+    override fun sql(builder: SqlBuilder) {
+        val depth = builder.depth
+        builder.append("SELECT expand(last(\$a${depth})) LET \$a${depth} = (")
+        source.sql(builder.deepen())
         builder.append(")")
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryTimeout.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryTimeout.kt
@@ -19,7 +19,7 @@ class OQueryTimeout(
     val timeoutMillis: Long
 ) : OQuery {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append(" TIMEOUT $timeoutMillis")
     }
 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OSkip.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OSkip.kt
@@ -25,7 +25,7 @@ class OSkipValue(
     val value: Int
 ) : OSkip {
 
-    override fun sql(builder: StringBuilder) {
+    override fun sql(builder: SqlBuilder) {
         builder.append(value)
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OSql.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/query/OSql.kt
@@ -16,5 +16,28 @@
 package jetbrains.exodus.entitystore.orientdb.query
 
 interface OSql {
-    fun sql(builder: StringBuilder)
+    fun sql(builder: SqlBuilder)
+}
+
+class SqlBuilder(
+    private val stringBuilder: StringBuilder = StringBuilder(),
+    val depth: Int = 0
+) {
+
+    fun append(value: Any): SqlBuilder {
+        stringBuilder.append(value)
+        return this
+    }
+
+    fun deepen(): SqlBuilder {
+        return SqlBuilder(stringBuilder, depth + 1)
+    }
+
+    fun build(): String {
+        return stringBuilder.toString()
+    }
+
+    override fun toString(): String {
+        return stringBuilder.toString()
+    }
 }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/query/OQueryTest.kt
@@ -23,7 +23,7 @@ class OQueryTest {
     fun `should select by property`() {
         val query = OClassSelect("Person", OEqualCondition("name", "John"))
 
-        val builder = StringBuilder()
+        val builder = SqlBuilder()
         query.sql(builder)
         println(builder)
         println(query.params())
@@ -34,7 +34,7 @@ class OQueryTest {
         val condition = OEqualCondition("name", "John").or(OEqualCondition("project", "Sample"))
         val query = OClassSelect("Person", condition)
 
-        val builder = StringBuilder()
+        val builder = SqlBuilder()
         query.sql(builder)
         println(builder)
         println(query.params())
@@ -45,7 +45,7 @@ class OQueryTest {
         val condition = OEqualCondition("name", "John").and(OEqualCondition("project", "Sample"))
         val query = OClassSelect("Person", condition)
 
-        val builder = StringBuilder()
+        val builder = SqlBuilder()
         query.sql(builder)
         println(builder)
         println(query.params())
@@ -62,7 +62,7 @@ class OQueryTest {
         )
         val query = OClassSelect("Person", condition)
 
-        val builder = StringBuilder()
+        val builder = SqlBuilder()
         query.sql(builder)
 
         println(builder)


### PR DESCRIPTION
Fix `kotlinx.dnq.query.IsInQueryTest` test by introducing unique LET argument names with depth using SqlBuilder instead of StringBuilder.

https://youtrack.jetbrains.com/issue/XD-1065/Fix-XDNQ-tests-related-to-query-generation