### PR TITLE
During the load entity is created in detached form and real record loaded only on the first request.

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
@@ -133,8 +133,7 @@ class OStoreTransactionImpl(
         if (oId == ORIDEntityId.EMPTY_ID) {
             throw EntityRemovedInDatabaseException(oId.getTypeName(), id)
         }
-        val vertex: OVertex = session.load(oId.asOId()) ?: throw EntityRemovedInDatabaseException(oId.getTypeName(), id)
-        return OVertexEntity(vertex, store)
+        return OVertexEntity(oId, store)
     }
 
     override fun getEntityTypes(): MutableList<String> {

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OrientDBIssues.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OrientDBIssues.kt
@@ -60,7 +60,7 @@ fun InMemoryOrientDB.createIssue(name: String, priority: String? = null): OVerte
     provider.acquireSession().use { session ->
         session.getOrCreateVertexClass(CLASS)
     }
-    return withSession { session ->
+    return withTxSession { session ->
         val issue = session.createNamedEntity(CLASS, name, store)
         priority?.let { issue.setProperty(PRIORITY, it) }
         issue.save()

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OModelMetaDataTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OModelMetaDataTest.kt
@@ -186,7 +186,7 @@ class OModelMetaDataTest {
         // prepare() must initialize internal data structures in the end
         model.prepare()
 
-        orientDb.withSession { session ->
+        orientDb.withSession {
             assertEquals(entityId, model.getOEntityId(oldSchoolEntityId))
         }
     }


### PR DESCRIPTION
This behaviour is needed to ensure that we can "load" deleted entities for DNQ.