### PR TITLE
Some fixes here and there

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/ODatabaseProvider.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/ODatabaseProvider.kt
@@ -35,6 +35,12 @@ interface ODatabaseProvider {
      */
     fun <T> executeInASeparateSession(currentSession: ODatabaseSession, action: (ODatabaseSession) -> T): T
 
+    /**
+     * Database-wise read-only mode.
+     * Always false by default.
+     */
+    var readOnly: Boolean
+
     fun close()
 }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
@@ -121,6 +121,16 @@ class OStoreTransactionImpl(
         check(session.isActiveOnCurrentThread) { "The session is not active on the current thread" }
         check(session.transaction is OTransactionNoTx) { "The session must not have a transaction" }
         try {
+            if (readOnly) {
+                /**
+                 * It is not enough to provide the best experience to the client code.
+                 * The session will throw an exception only on commit(), but not when
+                 * the client code creates/edits/deletes entities.
+                 *
+                 * So, we keep and check the readOnly flag too.
+                 */
+                session.freeze(true)
+            }
             session.begin()
             // initialize transaction id
             transactionIdImpl

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
@@ -121,16 +121,6 @@ class OStoreTransactionImpl(
         check(session.isActiveOnCurrentThread) { "The session is not active on the current thread" }
         check(session.transaction is OTransactionNoTx) { "The session must not have a transaction" }
         try {
-            if (readOnly) {
-                /**
-                 * It is not enough to provide the best experience to the client code.
-                 * The session will throw an exception only on commit(), but not when
-                 * the client code creates/edits/deletes entities.
-                 *
-                 * So, we keep and check the readOnly flag too.
-                 */
-                session.freeze(true)
-            }
             session.begin()
             // initialize transaction id
             transactionIdImpl

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OEntityIterableBase.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/OEntityIterableBase.kt
@@ -45,6 +45,7 @@ abstract class OEntityIterableBase(tx: OStoreTransaction) : OEntityIterable {
             override fun contains(entity: Entity): Boolean = false
             override fun isSortResult(): Boolean = true
             override fun asSortResult(): EntityIterable = this
+            override fun findLinks(entities: EntityIterable, linkName: String): EntityIterable = this
             override fun size() = 0L
             override fun getRoughSize() = 0L
             override fun count() = 0L
@@ -183,7 +184,7 @@ abstract class OEntityIterableBase(tx: OStoreTransaction) : OEntityIterable {
         return selectManyDistinct(linkName)
     }
 
-    fun findLinks(entities: EntityIterable, linkName: String): EntityIterable {
+    override fun findLinks(entities: EntityIterable, linkName: String): EntityIterable {
         if (entities == EMPTY) {
             return EMPTY
         }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/link/OVertexEntityIterable.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/iterate/link/OVertexEntityIterable.kt
@@ -115,5 +115,9 @@ class OVertexEntityIterable(
 
     override fun unwrap() = this
 
+    override fun findLinks(entities: EntityIterable, linkName: String): EntityIterable {
+        return asQueryIterable().findLinks(entities, linkName)
+    }
+
     private fun asQueryIterable() = OLinksFromEntityIterable(tx, linkName, this.targetEntityID)
 }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/ODatabaseProviderTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/ODatabaseProviderTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright ${inceptionYear} - ${year} ${owner}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jetbrains.exodus.entitystore.orientdb
 
 import com.orientechnologies.common.concur.lock.OModificationOperationProhibitedException

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/ODatabaseProviderTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/ODatabaseProviderTest.kt
@@ -1,0 +1,44 @@
+package jetbrains.exodus.entitystore.orientdb
+
+import com.orientechnologies.common.concur.lock.OModificationOperationProhibitedException
+import com.orientechnologies.orient.core.record.OVertex
+import jetbrains.exodus.entitystore.orientdb.testutil.InMemoryOrientDB
+import jetbrains.exodus.entitystore.orientdb.testutil.OTestMixin
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class ODatabaseProviderTest: OTestMixin {
+
+    @Rule
+    @JvmField
+    val orientDbRule = InMemoryOrientDB()
+
+    override val orientDb = orientDbRule
+
+    @Test
+    fun `read-only mode works`() {
+        // by default it is read-write
+        withSession { session ->
+            val v = session.newVertex()
+            v.save<OVertex>()
+        }
+
+        orientDb.provider.readOnly = true
+        withSession { session ->
+            val v = session.newVertex()
+            assertFailsWith<OModificationOperationProhibitedException> { v.save<OVertex>() }
+        }
+
+        orientDb.provider.readOnly = false
+        withSession { session ->
+            val v = session.newVertex()
+            v.save<OVertex>()
+        }
+
+        orientDb.provider.readOnly = true
+        // close() releases the read-only mode before closing the database (otherwise it throws exceptions)
+        orientDb.provider.close()
+    }
+
+}

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionLifecycleTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionLifecycleTest.kt
@@ -15,8 +15,6 @@
  */
 package jetbrains.exodus.entitystore.orientdb
 
-import com.orientechnologies.common.concur.lock.OModificationOperationProhibitedException
-import com.orientechnologies.orient.core.db.ODatabaseSession
 import com.orientechnologies.orient.core.metadata.schema.OClass
 import com.orientechnologies.orient.core.metadata.schema.OType
 import com.orientechnologies.orient.core.record.OVertex
@@ -118,17 +116,5 @@ class OStoreTransactionLifecycleTest : OTestMixin {
                 "abort" -> txAction(tx)
             }
         }
-    }
-
-    @Test
-    fun `read-only transaction freezes the session`() {
-        beginReadonlyTransaction()
-        val session = ODatabaseSession.getActiveSession() as ODatabaseSession
-
-        val v = session.newVertex()
-        v.save<OVertex>()
-        assertFailsWith<OModificationOperationProhibitedException> { session.commit() }
-
-        session.close()
     }
 }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OTestMixin.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OTestMixin.kt
@@ -41,6 +41,11 @@ interface OTestMixin {
         return store.beginTransaction() as OStoreTransactionImpl
     }
 
+    fun beginReadonlyTransaction(): OStoreTransactionImpl {
+        val store = orientDb.store
+        return store.beginReadonlyTransaction() as OStoreTransactionImpl
+    }
+
     fun <R> withStoreTx(block: (OStoreTransaction) -> R): R {
         return orientDb.withStoreTx(block)
     }

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/EntityIterable.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/EntityIterable.java
@@ -307,12 +307,11 @@ public interface EntityIterable extends Iterable<Entity> {
     @NotNull
     EntityIterable asSortResult();
 
-
-  /**
-   * This method is a default method is used to get the original {@code EntityIterable} when wrapped up.
-   *
-   * @return the unwrapped {@code EntityIterable}. By default, it returns the current instance.
-   */
+    /**
+     * This method is a default method is used to get the original {@code EntityIterable} when wrapped up.
+     *
+     * @return the unwrapped {@code EntityIterable}. By default, it returns the current instance.
+     */
     @NotNull
     EntityIterable unwrap();
 

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/EntityIterable.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/EntityIterable.java
@@ -315,4 +315,6 @@ public interface EntityIterable extends Iterable<Entity> {
    */
     @NotNull
     EntityIterable unwrap();
+
+    EntityIterable findLinks(@NotNull final EntityIterable entities, @NotNull final String linkName);
 }

--- a/query/src/main/kotlin/jetbrains/exodus/query/InMemoryEntityIterable.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/InMemoryEntityIterable.kt
@@ -132,6 +132,9 @@ class InMemoryEntityIterable(
         return this
     }
 
+    override fun findLinks(entities: EntityIterable, linkName: String): EntityIterable {
+        throw NotImplementedError()
+    }
 }
 
 internal class InMemoryEntityIterator(val iterator: Iterator<Entity>) : EntityIterator {


### PR DESCRIPTION
1. Supported the database-wise read-only mode. 
    * If there are active write transactions at the moment when the read-only mode gets enabled, those transactions will fail on commit.
3. Moved findLinks(...) method to EntityIterable. So, it is declared and available on the interface level.