### PR TITLE
Support adding new links in a transaction

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransaction.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransaction.kt
@@ -15,6 +15,7 @@
  */
 package jetbrains.exodus.entitystore.orientdb
 
+import com.orientechnologies.orient.core.metadata.schema.OClass
 import com.orientechnologies.orient.core.metadata.sequence.OSequence
 import com.orientechnologies.orient.core.record.ORecord
 import com.orientechnologies.orient.core.record.OVertex
@@ -59,4 +60,6 @@ interface OStoreTransaction : StoreTransaction {
     fun updateOSequence(sequenceName: String, currentValue: Long)
 
     fun renameOClass(oldName: String, newName: String)
+
+    fun getOrCreateEdgeClass(linkName: String, outClassName: String, inClassName: String): OClass
 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
@@ -192,6 +192,7 @@ class OStoreTransactionImpl(
 
     override fun newEntity(entityType: String, localEntityId: Long): OVertexEntity {
         requireActiveWritableTransaction()
+        schemaBuddy.requireTypeExists(session, entityType)
         val vertex = session.newVertex(entityType)
         vertex.setProperty(LOCAL_ENTITY_ID_PROPERTY_NAME, localEntityId)
         vertex.save<OVertex>()

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OStoreTransactionImpl.kt
@@ -17,6 +17,7 @@ package jetbrains.exodus.entitystore.orientdb
 
 import com.orientechnologies.orient.core.db.ODatabase
 import com.orientechnologies.orient.core.db.ODatabaseSession
+import com.orientechnologies.orient.core.metadata.schema.OClass
 import com.orientechnologies.orient.core.metadata.sequence.OSequence
 import com.orientechnologies.orient.core.record.ORecord
 import com.orientechnologies.orient.core.record.OVertex
@@ -399,6 +400,11 @@ class OStoreTransactionImpl(
     override fun renameOClass(oldName: String, newName: String) {
         requireActiveTransaction()
         schemaBuddy.renameOClass(session, oldName, newName)
+    }
+
+    override fun getOrCreateEdgeClass(linkName: String, outClassName: String, inClassName: String): OClass {
+        requireActiveTransaction()
+        return schemaBuddy.getOrCreateEdgeClass(session, linkName, outClassName, inClassName)
     }
 
     override fun setQueryCancellingPolicy(policy: QueryCancellingPolicy?) {

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/orientdb/OVertexEntity.kt
@@ -15,7 +15,6 @@
  */
 package jetbrains.exodus.entitystore.orientdb
 
-import com.orientechnologies.orient.core.db.ODatabaseSession
 import com.orientechnologies.orient.core.db.record.OTrackedSet
 import com.orientechnologies.orient.core.db.record.ridbag.ORidBag
 import com.orientechnologies.orient.core.id.ORID
@@ -275,10 +274,10 @@ open class OVertexEntity(internal val vertex: OVertex, private val store: OEntit
     }
 
     private fun OStoreTransaction.addLinkImpl(linkName: String, target: OVertex): Boolean {
+        val outClassName = vertex.requireSchemaClass().name
+        val inClassName = target.requireSchemaClass().name
+        val edgeClass = getOrCreateEdgeClass(linkName, outClassName, inClassName)
         val edgeClassName = edgeClassName(linkName)
-//        this.requi
-//        val edgeClass = this.getOrCreateEdgeClass(edgeClassName)
-        val edgeClass = ODatabaseSession.getActiveSession().getClass(edgeClassName) ?: throw IllegalStateException("$edgeClassName edge class not found in the database. Sorry, pal, it is required for adding a link.")
 
         /*
         We check for duplicates only if there is an appropriate index for it.

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/ODatabaseProviderTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/ODatabaseProviderTest.kt
@@ -34,19 +34,21 @@ class ODatabaseProviderTest: OTestMixin {
     @Test
     fun `read-only mode works`() {
         // by default it is read-write
-        withSession { session ->
+        withTxSession { session ->
             val v = session.newVertex()
             v.save<OVertex>()
         }
 
         orientDb.provider.readOnly = true
-        withSession { session ->
-            val v = session.newVertex()
-            assertFailsWith<OModificationOperationProhibitedException> { v.save<OVertex>() }
+        assertFailsWith<OModificationOperationProhibitedException> {
+            withTxSession { session ->
+                val v = session.newVertex()
+                v.save<OVertex>()
+            }
         }
 
         orientDb.provider.readOnly = false
-        withSession { session ->
+        withTxSession { session ->
             val v = session.newVertex()
             v.save<OVertex>()
         }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OEntityTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OEntityTest.kt
@@ -19,9 +19,7 @@ import com.orientechnologies.orient.core.metadata.schema.OType
 import jetbrains.exodus.entitystore.EntityRemovedInDatabaseException
 import jetbrains.exodus.entitystore.PersistentEntityId
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.linkTargetEntityIdPropertyName
-import jetbrains.exodus.entitystore.orientdb.testutil.InMemoryOrientDB
-import jetbrains.exodus.entitystore.orientdb.testutil.Issues
-import jetbrains.exodus.entitystore.orientdb.testutil.createIssue
+import jetbrains.exodus.entitystore.orientdb.testutil.*
 import jetbrains.exodus.entitystore.orientdb.testutil.createIssueImpl
 import org.junit.Rule
 import org.junit.Test
@@ -30,11 +28,13 @@ import java.util.*
 import kotlin.random.Random
 import kotlin.test.*
 
-class OEntityTest {
+class OEntityTest: OTestMixin {
 
     @Rule
     @JvmField
-    val orientDb = InMemoryOrientDB()
+    val orientDbRule = InMemoryOrientDB()
+
+    override val orientDb = orientDbRule
 
     @Test
     fun `create entities`() {
@@ -632,5 +632,15 @@ class OEntityTest {
         }
         assertEquals(1001, localIdSet.size)
         assertEquals(1, typeIdSet.size)
+    }
+
+    @Test
+    fun `add new link types in a transaction`() {
+        withStoreTx { tx ->
+            val iss1 = tx.createIssue("iss1")
+            val iss2 = tx.createIssue("iss2")
+
+            iss1.addLink("trista", iss2)
+        }
     }
 }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OTransactionLifecycleTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/OTransactionLifecycleTest.kt
@@ -42,15 +42,11 @@ class OTransactionLifecycleTest : OTestMixin {
     @Test
     fun `session-freeze(true) makes the session read-only`() {
         val session = orientDb.openSession()
-
         session.freeze(true)
+        session.begin()
 
         val v = session.newVertex()
-        assertFailsWith<OModificationOperationProhibitedException> { v.save<OVertex>() }
-
-        session.begin()
-        val v1 = session.newVertex()
-        v1.save<OVertex>()
+        v.save<OVertex>()
         assertFailsWith<OModificationOperationProhibitedException> { session.commit() }
 
         // after release() we can write again

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/InMemoryOrientDB.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/InMemoryOrientDB.kt
@@ -71,17 +71,8 @@ class InMemoryOrientDB(
     val database get() = db
 
     fun <R> withStoreTx(block: (OStoreTransaction) -> R): R {
-        val tx = store.beginTransaction() as OStoreTransaction
-        try {
-            val result = block(tx)
-            if (!tx.isFinished) {
-                tx.commit()
-            }
-            return result
-        } finally {
-            if (!tx.isFinished) {
-                tx.abort()
-            }
+        return store.computeInTransaction { tx ->
+            block(tx as OStoreTransaction)
         }
     }
 

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OTestMixin.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/orientdb/testutil/OTestMixin.kt
@@ -54,6 +54,10 @@ interface OTestMixin {
         return orientDb.withSession(block)
     }
 
+    fun <R> withTxSession(block: (ODatabaseSession) -> R): R {
+        return orientDb.withTxSession(block)
+    }
+
     fun givenTestCase() = OTaskTrackerTestCase(orientDb)
 
     fun OStoreTransaction.createIssue(name: String, priority: String? = null): OVertexEntity = createIssueImpl(name, priority)

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/CountingTransaction.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/CountingTransaction.kt
@@ -62,7 +62,9 @@ internal class CountingTransaction(
     }
 
     fun rollback() {
-        txn.abort()
+        if (!txn.isFinished) {
+            txn.abort()
+        }
     }
 
     fun newVertex(type: String, localEntityId: Long): OVertexEntity {

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializer.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializer.kt
@@ -353,33 +353,34 @@ internal class OrientDbSchemaInitializer(
         appendLine()
 
         withPadding {
-            // class1.prop1 -> edgeClass -> class2
-            applyLink(
+            if (applyLinkCardinality) {
+                applyLinkCardinality(
+                    edgeClass,
+                    outClass,
+                    link.cardinality,
+                    inClass,
+                )
+            }
+            applyIndices(
                 link.name,
                 edgeClass,
                 outClass,
-                link.cardinality,
-                inClass,
                 indicesContainingLink
             )
         }
     }
 
-    private fun applyLink(
-        linkName: String,
+    private fun applyLinkCardinality(
         edgeClass: OClass,
         outClass: OClass,
         outCardinality: AssociationEndCardinality,
         inClass: OClass,
-        indicesContainingLink: List<Index>
     ) {
         val linkOutPropName = OVertex.getEdgeLinkFieldName(ODirection.OUT, edgeClass.name)
         append("outProp: ${outClass.name}.$linkOutPropName")
         val outProp = outClass.createLinkPropertyIfAbsent(linkOutPropName)
-        if (applyLinkCardinality) {
-            // applying cardinality only to out direct property
-            outProp.applyCardinality(outCardinality)
-        }
+        // applying cardinality only to out direct property
+        outProp.applyCardinality(outCardinality)
         appendLine()
 
         val linkInPropName = OVertex.getEdgeLinkFieldName(ODirection.IN, edgeClass.name)
@@ -391,7 +392,14 @@ internal class OrientDbSchemaInitializer(
         * We do not apply cardinality for the in-properties because, we do not know if there is any restrictions.
         * Because AssociationEndCardinality describes the cardinality of a single end.
         * */
+    }
 
+    private fun applyIndices(
+        linkName: String,
+        edgeClass: OClass,
+        outClass: OClass,
+        indicesContainingLink: List<Index>
+    ) {
         addIndex(linkUniqueIndex(edgeClass.name))
 
         if (indicesContainingLink.isNotEmpty()) {

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OModelMetaDataTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OModelMetaDataTest.kt
@@ -17,12 +17,10 @@ package jetbrains.exodus.query.metadata
 
 import com.orientechnologies.orient.core.record.OVertex
 import jetbrains.exodus.entitystore.PersistentEntityId
-import jetbrains.exodus.entitystore.orientdb.ORIDEntityId
-import jetbrains.exodus.entitystore.orientdb.OSchemaBuddyImpl
+import jetbrains.exodus.entitystore.orientdb.*
 import jetbrains.exodus.entitystore.orientdb.OVertexEntity.Companion.linkTargetEntityIdPropertyName
-import jetbrains.exodus.entitystore.orientdb.createVertexClassWithClassId
-import jetbrains.exodus.entitystore.orientdb.getTargetLocalEntityIds
 import jetbrains.exodus.entitystore.orientdb.testutil.InMemoryOrientDB
+import jetbrains.exodus.entitystore.orientdb.testutil.OTestMixin
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -31,10 +29,12 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class OModelMetaDataTest {
+class OModelMetaDataTest: OTestMixin {
     @Rule
     @JvmField
-    val orientDb = InMemoryOrientDB(initializeIssueSchema = false)
+    val orientDbRule = InMemoryOrientDB(initializeIssueSchema = false)
+
+    override val orientDb = orientDbRule
 
     @Test
     fun `prepare() applies the schema to OrientDB`() {
@@ -257,6 +257,59 @@ class OModelMetaDataTest {
 
             session.checkIndex("type1", true, linkTargetEntityIdPropertyName("ass1"))
             session.checkIndex("type2", true, linkTargetEntityIdPropertyName("ass2"))
+        }
+    }
+
+    @Test
+    fun `oModel creates the schema for links if it is absent`() {
+        val model = oModel(orientDb.provider) {
+            entity("type1")
+            entity("type2")
+        }
+        // initialize the entity types
+        model.prepare()
+        val store = OPersistentEntityStore(orientDb.provider, orientDb.dbName, model)
+
+        // check that the links do not exist
+        withSession { session ->
+            session.assertAssociationNotExist("type1", "type2", "link1")
+            session.assertAssociationNotExist("type2", "type1", "link2")
+        }
+
+        // add the links, the necessary schema parts should be initialized on the way
+        store.executeInTransaction { tx ->
+            val e1 = tx.newEntity("type1")
+            val e2 = tx.newEntity("type2")
+            e1.addLink("link1", e2)
+            e2.addLink("link2", e1)
+        }
+
+        withSession { session ->
+            // check that the necessary schema parts have been initialized
+            session.assertAssociationExists("type1", "type2", "link1", AssociationEndCardinality._0_n)
+            session.assertAssociationExists("type2", "type1", "link2", AssociationEndCardinality._0_n)
+
+            /**
+             * It is a tricky one.
+             * We have type2 -link2-> type1 link.
+             * But we do not have type2 -link1-> type1 link yet.
+             * So, the necessary schema parts must not be initialized for type2 -link1-> type1,
+             * except for the link1 edge class itself. It must be initialized already. We
+             * share edge classes between all the links with the same name.
+             */
+            session.assertAssociationNotExist("type2", "type1", "link1", requireEdgeClass = true)
+        }
+
+        // add a type2 -link1-> type1 link
+        store.executeInTransaction { tx ->
+            val e1 = tx.newEntity("type1")
+            val e2 = tx.newEntity("type2")
+            e2.addLink("link1", e1)
+        }
+
+        // check that the necessary schema parts have been initialized
+        withSession { session ->
+            session.assertAssociationExists("type2", "type1", "link1", AssociationEndCardinality._0_n)
         }
     }
 }

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/OrientDbSchemaInitializerTest.kt
@@ -183,7 +183,8 @@ class OrientDbSchemaInitializerTest {
             }
         }
 
-        oSession.applySchema(model)
+        val result = oSession.applySchema(model)
+        oSession.initializeIndices(result)
 
         for (cardinality in AssociationEndCardinality.entries) {
             oSession.assertAssociationExists("type2", "type1", "prop1$cardinality", cardinality)
@@ -200,7 +201,8 @@ class OrientDbSchemaInitializerTest {
             association("type3", "link1", "type1", AssociationEndCardinality._0_n)
         }
 
-        oSession.applySchema(model)
+        val result = oSession.applySchema(model)
+        oSession.initializeIndices(result)
 
         oSession.assertAssociationExists("type2", "type1", "link1", AssociationEndCardinality._0_n)
         oSession.assertAssociationExists("type3", "type1", "link1", AssociationEndCardinality._0_n)
@@ -216,7 +218,8 @@ class OrientDbSchemaInitializerTest {
             }
         }
 
-        oSession.applySchema(model, applyLinkCardinality = false)
+        val result = oSession.applySchema(model, applyLinkCardinality = false)
+        oSession.initializeIndices(result)
 
         for (cardinality in AssociationEndCardinality.entries) {
             oSession.assertAssociationExists("type2", "type1", "prop1$cardinality", null)
@@ -243,7 +246,8 @@ class OrientDbSchemaInitializerTest {
             }
         }
 
-        oSession.applySchema(model)
+        val result = oSession.applySchema(model)
+        oSession.initializeIndices(result)
 
         for (cardinality1 in AssociationEndCardinality.entries) {
             for (cardinality2 in AssociationEndCardinality.entries) {
@@ -374,18 +378,20 @@ class OrientDbSchemaInitializerTest {
             entity("type2")
         }
 
-        session.applySchema(model)
+        val result = session.applySchema(model)
+        session.initializeIndices(result)
 
         for (cardinality in AssociationEndCardinality.entries) {
-            session.addAssociation(
-                model.getEntityMetaData("type1")!!,
-                OAssociationMetadata(
+            val assResult = session.addAssociation(
+                LinkMetadata(
                     name = "ass1${cardinality.name}",
                     outClassName = "type1",
                     inClassName = "type2",
                     cardinality = cardinality
-                )
+                ),
+                listOf()
             )
+            session.initializeIndices(assResult)
         }
 
         for (cardinality in AssociationEndCardinality.entries) {

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
@@ -53,26 +53,28 @@ internal fun ODatabaseSession.assertAssociationExists(
     outClassName: String,
     inClassName: String,
     edgeName: String,
-    cardinality: AssociationEndCardinality?
+    cardinality: AssociationEndCardinality?,
 ) {
     val edgeClassName = edgeName.asEdgeClass
     val edgeClass = getClass(edgeClassName)
     val inClass = getClass(inClassName)!!
     val outClass = getClass(outClassName)!!
 
-    val outPropName = OVertex.getEdgeLinkFieldName(ODirection.OUT, edgeClassName)
-    val directOutProp = outClass.getProperty(outPropName)!!
-    assertEquals(OType.LINKBAG, directOutProp.type)
-    directOutProp.assertCardinality(cardinality)
-
-    val inPropName = OVertex.getEdgeLinkFieldName(ODirection.IN, edgeClassName)
-    val directInProp = inClass.getProperty(inPropName)!!
-    assertEquals(OType.LINKBAG, directInProp.type)
-
     assertTrue(edgeClass.areIndexed(OEdge.DIRECTION_IN, OEdge.DIRECTION_OUT))
+
+    if (cardinality != null) {
+        val outPropName = OVertex.getEdgeLinkFieldName(ODirection.OUT, edgeClassName)
+        val directOutProp = outClass.getProperty(outPropName)!!
+        assertEquals(OType.LINKBAG, directOutProp.type)
+        directOutProp.assertCardinality(cardinality)
+
+        val inPropName = OVertex.getEdgeLinkFieldName(ODirection.IN, edgeClassName)
+        val directInProp = inClass.getProperty(inPropName)!!
+        assertEquals(OType.LINKBAG, directInProp.type)
+    }
 }
 
-private fun OProperty.assertCardinality(cardinality: AssociationEndCardinality?) {
+private fun OProperty.assertCardinality(cardinality: AssociationEndCardinality) {
     when (cardinality) {
         AssociationEndCardinality._0_1 -> {
             assertTrue(!this.isMandatory)
@@ -95,12 +97,6 @@ private fun OProperty.assertCardinality(cardinality: AssociationEndCardinality?)
         AssociationEndCardinality._1_n -> {
             assertTrue(this.isMandatory)
             assertTrue(this.min == "1")
-            assertTrue(this.max == null)
-        }
-
-        null -> {
-            assertTrue(!this.isMandatory)
-            assertTrue(this.min == null)
             assertTrue(this.max == null)
         }
     }

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
@@ -20,6 +20,7 @@ import com.orientechnologies.orient.core.metadata.schema.OClass
 import com.orientechnologies.orient.core.metadata.schema.OProperty
 import com.orientechnologies.orient.core.metadata.schema.OType
 import com.orientechnologies.orient.core.record.ODirection
+import com.orientechnologies.orient.core.record.OEdge
 import com.orientechnologies.orient.core.record.OVertex
 import jetbrains.exodus.entitystore.orientdb.*
 import org.junit.Assert.*
@@ -32,17 +33,19 @@ internal fun ODatabaseSession.assertAssociationNotExist(
     edgeName: String,
     requireEdgeClass: Boolean = false
 ) {
+    val edgeClassName = edgeName.asEdgeClass
     if (requireEdgeClass) {
-        requireEdgeClass(edgeName.asEdgeClass)
+        val edgeClass = requireEdgeClass(edgeClassName)
+        assertTrue(edgeClass.areIndexed(OEdge.DIRECTION_IN, OEdge.DIRECTION_OUT))
     }
 
     val inClass = getClass(inClassName)!!
     val outClass = getClass(outClassName)!!
 
-    val outPropName = OVertex.getEdgeLinkFieldName(ODirection.OUT, edgeName)
+    val outPropName = OVertex.getEdgeLinkFieldName(ODirection.OUT, edgeClassName)
     assertNull(outClass.getProperty(outPropName))
 
-    val inPropName = OVertex.getEdgeLinkFieldName(ODirection.IN, edgeName)
+    val inPropName = OVertex.getEdgeLinkFieldName(ODirection.IN, edgeClassName)
     assertNull(inClass.getProperty(inPropName))
 }
 
@@ -52,18 +55,21 @@ internal fun ODatabaseSession.assertAssociationExists(
     edgeName: String,
     cardinality: AssociationEndCardinality?
 ) {
-    val edgeClass = edgeName.asEdgeClass
+    val edgeClassName = edgeName.asEdgeClass
+    val edgeClass = getClass(edgeClassName)
     val inClass = getClass(inClassName)!!
     val outClass = getClass(outClassName)!!
 
-    val outPropName = OVertex.getEdgeLinkFieldName(ODirection.OUT, edgeClass)
+    val outPropName = OVertex.getEdgeLinkFieldName(ODirection.OUT, edgeClassName)
     val directOutProp = outClass.getProperty(outPropName)!!
     assertEquals(OType.LINKBAG, directOutProp.type)
     directOutProp.assertCardinality(cardinality)
 
-    val inPropName = OVertex.getEdgeLinkFieldName(ODirection.IN, edgeClass)
+    val inPropName = OVertex.getEdgeLinkFieldName(ODirection.IN, edgeClassName)
     val directInProp = inClass.getProperty(inPropName)!!
     assertEquals(OType.LINKBAG, directInProp.type)
+
+    assertTrue(edgeClass.areIndexed(OEdge.DIRECTION_IN, OEdge.DIRECTION_OUT))
 }
 
 private fun OProperty.assertCardinality(cardinality: AssociationEndCardinality?) {


### PR DESCRIPTION
1. Supported adding new link types in a transaction. For such links, we create only the edge class and the unique index. We do not add "in and out" properties to the vertex classes, because it does not bring any value (we do not have any cardinality restrictions for ad-hoc links), and it may cause concurrency errors (see the tests for details).
2. A couple of fixes here and there.