### PR TITLE
Dropped unnecessary ClassCast

### DIFF
--- a/query/src/main/kotlin/jetbrains/exodus/query/SortEngine.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/SortEngine.kt
@@ -45,7 +45,7 @@ open class SortEngine {
                 }
                 val i = queryEngine.toEntityIterable(source)
                 if (queryEngine.isPersistentIterable(i)) {
-                    val it = (i as OEntityIterableBase).unwrap()
+                    val it = (i as EntityIterable).unwrap()
                     if (it === OEntityIterableBase.EMPTY) {
                         OEntityIterableBase.EMPTY
                     }


### PR DESCRIPTION
### What does this PR do?

It did casts to OEntityIterableBase to call unwrap() where EntityIterable was enough

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
