### PR TITLE
XD-1195 propagated read-only mode flag to the store

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
@@ -193,6 +193,10 @@ class YTDBPersistentEntityStore(
     override fun getOEntityId(entityId: PersistentEntityId): YTDBEntityId {
         return requireActiveTransaction().getOEntityId(entityId)
     }
+
+    override fun isReadOnly(): Boolean {
+        return this.databaseProvider.readOnly
+    }
 }
 
 internal fun YTDBEntityStore.requireOEntityId(id: EntityId): YTDBEntityId {

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/OPersistentStoreTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/OPersistentStoreTest.kt
@@ -317,4 +317,11 @@ class OPersistentStoreTest : OTestMixin {
             }
         }
     }
+
+    @Test
+    fun `read-only mode flag is propagated to the store`() {
+        youTrackDb.provider.readOnly = true
+        assertEquals(true, youTrackDb.store.isReadOnly)
+        youTrackDb.provider.readOnly = false
+    }
 }

--- a/openAPI/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStore.java
+++ b/openAPI/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStore.java
@@ -157,4 +157,7 @@ public interface PersistentEntityStore extends EntityStore, Backupable {
 
     @NotNull
     StoreTransaction getAndCheckCurrentTransaction();
+
+    @NotNull
+    Boolean isReadOnly();
 }

--- a/persistent-entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
+++ b/persistent-entity-store/src/main/java/jetbrains/exodus/entitystore/PersistentEntityStoreImpl.java
@@ -2660,4 +2660,10 @@ public class PersistentEntityStoreImpl implements PersistentEntityStore, FlushLo
             }
         }
     }
+
+    @NotNull
+    @Override
+    public Boolean isReadOnly() {
+        return this.environment.isReadOnly();
+    }
 }


### PR DESCRIPTION
### What does this PR do?

propagate getter for read-only flag to the the store

### Motivation

The solution (cloud) is designed to use only `PersistentEntityStore` as the entry point for database access. It is necessary to assess whether the given store is in read-only mode.

### Related issues

https://youtrack.jetbrains.com/issue/XD-1195/

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
