### PR TITLE
XD-1199 reused db configs during db and provider initialisation, #XD-…

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseFactory.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseFactory.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright ${inceptionYear} - ${year} ${owner}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import com.jetbrains.youtrack.db.api.YouTrackDB
 import com.jetbrains.youtrack.db.api.YourTracks
 import com.jetbrains.youtrack.db.api.config.GlobalConfiguration

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseFactory.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseFactory.kt
@@ -1,0 +1,54 @@
+import com.jetbrains.youtrack.db.api.YouTrackDB
+import com.jetbrains.youtrack.db.api.YourTracks
+import com.jetbrains.youtrack.db.api.config.GlobalConfiguration
+import com.jetbrains.youtrack.db.api.config.YouTrackDBConfig
+import com.jetbrains.youtrack.db.internal.core.db.YouTrackDBImpl
+import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseConfig
+import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProvider
+import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProviderImpl
+import java.util.*
+
+object YouTrackDBConfigFactory {
+
+    fun createDefaultDBConfig(params: YTDBDatabaseConfig): YouTrackDBConfig {
+        return YouTrackDBConfig.builder()
+            .addGlobalConfigurationParameter(GlobalConfiguration.AUTO_CLOSE_AFTER_DELAY, true)
+            .addGlobalConfigurationParameter(GlobalConfiguration.AUTO_CLOSE_DELAY, params.closeAfterDelayTimeout)
+            .addGlobalConfigurationParameter(GlobalConfiguration.NON_TX_READS_WARNING_MODE, "SILENT")
+            .apply {
+                params.cipherKey?.also { key ->
+                    addGlobalConfigurationParameter(
+                        GlobalConfiguration.STORAGE_ENCRYPTION_KEY,
+                        Base64.getEncoder().encodeToString(key)
+                    )
+                }
+            }
+            .apply(params.tweakConfig)
+            .build()
+    }
+}
+
+object YouTrackDBFactory {
+
+    fun initYouTrackDb(params: YTDBDatabaseConfig, dbConfig: YouTrackDBConfig): YouTrackDB {
+        return YourTracks.embedded(params.connectionConfig.databaseRoot, dbConfig).apply {
+            (this as? YouTrackDBImpl)?.let {
+                it.serverPassword = params.connectionConfig.password
+                it.serverUser = params.connectionConfig.userName
+            }
+        }
+    }
+}
+
+object YTDBDatabaseProviderFactory {
+
+    fun createProviderWithDb(params: YTDBDatabaseConfig): YTDBDatabaseProvider {
+        val dbConfig = YouTrackDBConfigFactory.createDefaultDBConfig(params)
+        val youTrackDb = YouTrackDBFactory.initYouTrackDb(params, dbConfig)
+        return createProvider(params, youTrackDb, dbConfig)
+    }
+
+    fun createProvider(params: YTDBDatabaseConfig, db: YouTrackDB, dbConfig: YouTrackDBConfig): YTDBDatabaseProvider {
+        return YTDBDatabaseProviderImpl(params, db, dbConfig)
+    }
+}

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
@@ -16,13 +16,7 @@
 package jetbrains.exodus.entitystore.youtrackdb
 
 import com.jetbrains.youtrack.db.api.DatabaseSession
-import com.jetbrains.youtrack.db.api.YouTrackDB
-import com.jetbrains.youtrack.db.api.YourTracks
-import com.jetbrains.youtrack.db.api.config.GlobalConfiguration
-import com.jetbrains.youtrack.db.api.config.YouTrackDBConfig
-import com.jetbrains.youtrack.db.api.exception.RecordDuplicatedException
 import com.jetbrains.youtrack.db.internal.core.db.DatabaseRecordThreadLocal
-import com.jetbrains.youtrack.db.internal.core.db.YouTrackDBImpl
 
 interface YTDBDatabaseProvider {
     val databaseLocation: String
@@ -93,21 +87,4 @@ internal fun requireNoActiveSession() {
 internal fun hasActiveSession(): Boolean {
     val db = DatabaseRecordThreadLocal.instance().getIfDefined()
     return db != null
-}
-
-fun initYouTrackDb(config: YTDBDatabaseConnectionConfig): YouTrackDB {
-    val orientConfig = YouTrackDBConfig.builder().apply {
-        addGlobalConfigurationParameter(GlobalConfiguration.AUTO_CLOSE_AFTER_DELAY, true)
-        addGlobalConfigurationParameter(
-            GlobalConfiguration.AUTO_CLOSE_DELAY,
-            config.closeAfterDelayTimeout
-        )
-        addGlobalConfigurationParameter(GlobalConfiguration.NON_TX_READS_WARNING_MODE, "SILENT")
-    }.build()
-    return YourTracks.embedded(config.databaseRoot, orientConfig).apply {
-        (this as? YouTrackDBImpl)?.let {
-            it.serverPassword = config.password
-            it.serverUser = config.userName
-        }
-    }
 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
@@ -17,38 +17,21 @@ package jetbrains.exodus.entitystore.youtrackdb
 
 import com.jetbrains.youtrack.db.api.DatabaseSession
 import com.jetbrains.youtrack.db.api.YouTrackDB
-import com.jetbrains.youtrack.db.api.config.GlobalConfiguration
 import com.jetbrains.youtrack.db.api.config.YouTrackDBConfig
 import java.io.File
-import java.util.*
 
 //username and password are considered to be same for all databases
 //todo this params also should be collected in some config entity
 class YTDBDatabaseProviderImpl(
     private val config: YTDBDatabaseConfig,
-    private val database: YouTrackDB
+    private val database: YouTrackDB,
+    private val dbConfig: YouTrackDBConfig = YouTrackDBConfigFactory.createDefaultDBConfig(config)
 ) : YTDBDatabaseProvider {
-    private val youTrackDBConfig: YouTrackDBConfig
     override var isOpen: Boolean = false
         private set
 
     init {
         require(config.connectionConfig.userName.matches(Regex("^[a-zA-Z0-9]*$")))
-
-        youTrackDBConfig = YouTrackDBConfig.builder().apply {
-            addGlobalConfigurationParameter(GlobalConfiguration.AUTO_CLOSE_AFTER_DELAY, true)
-            addGlobalConfigurationParameter(
-                GlobalConfiguration.AUTO_CLOSE_DELAY,
-                config.closeAfterDelayTimeout
-            )
-            config.cipherKey?.let {
-                addGlobalConfigurationParameter(
-                    GlobalConfiguration.STORAGE_ENCRYPTION_KEY,
-                    Base64.getEncoder().encodeToString(it)
-                )
-            }
-            config.tweakConfig(this)
-        }.build()
 
         database.createIfNotExists(
             config.databaseName,
@@ -125,7 +108,7 @@ class YTDBDatabaseProviderImpl(
             config.databaseName,
             config.connectionConfig.userName,
             config.connectionConfig.password,
-            youTrackDBConfig
+            dbConfig
         ).acquire()
     }
 

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/DBCompactTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/DBCompactTest.kt
@@ -35,7 +35,7 @@ class DBCompactTest {
                 tx.createIssueImpl("Test issue $it")
             }
         }
-        orientDb.provider.compact()
+        (orientDb.provider as YTDBDatabaseProviderImpl).compact()
         orientDb.withStoreTx {
             val size = it.getAll(Issues.CLASS).size()
             Assert.assertEquals(100, size)

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/WrongUsernameTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/WrongUsernameTest.kt
@@ -15,15 +15,13 @@
  */
 package jetbrains.exodus.entitystore.orientdb
 
+import YTDBDatabaseProviderFactory
 import com.jetbrains.youtrack.db.api.DatabaseType
 import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseConfig
 import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseConnectionConfig
-import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProvider
-import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProviderImpl
-import jetbrains.exodus.entitystore.youtrackdb.initYouTrackDb
+import org.junit.Test
 import java.nio.file.Files
 import kotlin.io.path.absolutePathString
-import org.junit.Test
 
 class WrongUsernameTest {
 
@@ -36,12 +34,11 @@ class WrongUsernameTest {
             .withDatabaseType(DatabaseType.MEMORY)
             .withDatabaseRoot(Files.createTempDirectory("haha").absolutePathString())
             .build()
-        val db = initYouTrackDb(cfg)
         val config = YTDBDatabaseConfig.builder()
             .withDatabaseName("hello")
             .withConnectionConfig(cfg)
             .build()
-        YTDBDatabaseProviderImpl(config, db)
+        YTDBDatabaseProviderFactory.createProviderWithDb(config)
     }
 
 

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/InMemoryYouTrackDB.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/InMemoryYouTrackDB.kt
@@ -18,8 +18,6 @@ package jetbrains.exodus.entitystore.youtrackdb.testutil
 import com.jetbrains.youtrack.db.api.DatabaseSession
 import com.jetbrains.youtrack.db.api.DatabaseType
 import com.jetbrains.youtrack.db.api.YouTrackDB
-import com.jetbrains.youtrack.db.api.config.GlobalConfiguration
-import com.jetbrains.youtrack.db.api.config.YouTrackDBConfig
 import jetbrains.exodus.entitystore.youtrackdb.*
 import jetbrains.exodus.entitystore.youtrackdb.testutil.Issues.Links.IN_PROJECT
 import jetbrains.exodus.entitystore.youtrackdb.testutil.Issues.Links.ON_BOARD
@@ -37,7 +35,7 @@ class InMemoryYouTrackDB(
     lateinit var store: YTDBPersistentEntityStore
         private set
 
-    lateinit var provider: YTDBDatabaseProviderImpl
+    lateinit var provider: YTDBDatabaseProvider
     lateinit var schemaBuddy: YTDBSchemaBuddyImpl
 
     val username = "admin"
@@ -56,10 +54,10 @@ class InMemoryYouTrackDB(
             .withConnectionConfig(connConfig)
             .withDatabaseName(dbName)
             .build()
-        val builder = YouTrackDBConfig.builder()
-        builder.addGlobalConfigurationParameter(GlobalConfiguration.NON_TX_READS_WARNING_MODE, "SILENT")
-        db = initYouTrackDb(connConfig)
-        provider = YTDBDatabaseProviderImpl(config, db)
+
+        val dbConfig = YouTrackDBConfigFactory.createDefaultDBConfig(config)
+        db = YouTrackDBFactory.initYouTrackDb(config, dbConfig)
+        provider = YTDBDatabaseProviderFactory.createProvider(config, db, dbConfig) as YTDBDatabaseProviderImpl
 
         if (initializeIssueSchema) {
             provider.withSession { session ->

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrient.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrient.kt
@@ -17,10 +17,7 @@ package jetbrains.exodus.query.metadata
 
 
 import com.jetbrains.youtrack.db.api.DatabaseType
-import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseConfig
-import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseConnectionConfig
-import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProviderImpl
-import jetbrains.exodus.entitystore.youtrackdb.initYouTrackDb
+import jetbrains.exodus.entitystore.youtrackdb.*
 
 fun main() {
     val xodusDatabaseDirectory = requireParam("xodusDatabaseDirectory")
@@ -102,11 +99,12 @@ fun main() {
 
     val config = YTDBDatabaseConfig.builder()
         .withDatabaseName(orientDatabaseName)
+        .withConnectionConfig(connectionConfig)
         .build()
 
-    val db = initYouTrackDb(connectionConfig)
-    // create a provider
-    val dbProvider = YTDBDatabaseProviderImpl(config, db)
+    val dbConfig = YouTrackDBConfigFactory.createDefaultDBConfig(config)
+    val db = YouTrackDBFactory.initYouTrackDb(config, dbConfig)
+    val dbProvider = YTDBDatabaseProviderFactory.createProvider(config, db, dbConfig)
 
     val launcher = XodusToOrientDataMigratorLauncher(
         xodus = MigrateFromXodusConfig(

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
@@ -16,8 +16,6 @@
 package jetbrains.exodus.query.metadata
 
 import com.jetbrains.youtrack.db.api.DatabaseType
-import com.jetbrains.youtrack.db.api.config.GlobalConfiguration
-import com.jetbrains.youtrack.db.api.config.YouTrackDBConfig
 import com.jetbrains.youtrack.db.api.record.Direction
 import com.jetbrains.youtrack.db.api.record.Vertex
 import jetbrains.exodus.TestUtil
@@ -41,9 +39,6 @@ class MigrateXodusToOrientDbSmokeTest {
         val username = "admin"
         val password = "password"
         val dbName = "testDB"
-        // create the database
-        val builder = YouTrackDBConfig.builder()
-        builder.addGlobalConfigurationParameter(GlobalConfiguration.NON_TX_READS_WARNING_MODE, "SILENT")
         val connectionConfig = YTDBDatabaseConnectionConfig.builder()
             .withPassword(password)
             .withUserName(username)
@@ -56,10 +51,11 @@ class MigrateXodusToOrientDbSmokeTest {
             .withDatabaseName("MEMORY")
             .build()
 
-        val db = initYouTrackDb(connectionConfig)
+        val dbConfig = YouTrackDBConfigFactory.createDefaultDBConfig(config)
+        val db = YouTrackDBFactory.initYouTrackDb(config, dbConfig)
         db.execute("create database $dbName MEMORY users ( $username identified by '$password' role admin )")
         // create a provider
-        val dbProvider = YTDBDatabaseProviderImpl(config, db)
+        val dbProvider = YTDBDatabaseProviderFactory.createProvider(config, db, dbConfig)
 
         // 1.2 Create OModelMetadata
         // it is important to disable autoInitialize for the schemaBuddy,

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
@@ -16,10 +16,7 @@
 package jetbrains.exodus.query.metadata
 
 import com.jetbrains.youtrack.db.api.DatabaseType
-import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseConfig
-import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseConnectionConfig
-import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProviderImpl
-import jetbrains.exodus.entitystore.youtrackdb.initYouTrackDb
+import jetbrains.exodus.entitystore.youtrackdb.*
 import org.junit.Test
 import kotlin.test.Ignore
 
@@ -49,10 +46,12 @@ class MigrateYourDatabaseTest {
         
         val config = YTDBDatabaseConfig.builder()
             .withDatabaseName("testDB")
+            .withConnectionConfig(connectionConfig)
             .build()
 
-        val db = initYouTrackDb(connectionConfig)
-        val provider = YTDBDatabaseProviderImpl(config, db)
+        val dbConfig = YouTrackDBConfigFactory.createDefaultDBConfig(config)
+        val db = YouTrackDBFactory.initYouTrackDb(config, dbConfig)
+        val provider = YTDBDatabaseProviderFactory.createProvider(config, db, dbConfig)
         val launcher = XodusToOrientDataMigratorLauncher(
             orient = MigrateToOrientConfig(
                 db = db,


### PR DESCRIPTION
…1199 fix

### What does this PR do?

structured initialisation of db
reuse db configs

### Motivation

cypher key parameter from db parameters wasn't applied correctly

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
