### PR TITLE
Migration to the new version of YouTrackDB

### DIFF
--- a/entity-store/build.gradle.kts
+++ b/entity-store/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     api(project(":xodus-openAPI"))
-    api("io.youtrackdb:youtrackdb-core:1.0.0-20250415.152546-25")
+    api("io.youtrackdb:youtrackdb-core:1.0.0-20250416.175118-26")
 
     implementation(project(":xodus-utils"))
     implementation(project(":xodus-environment"))

--- a/entity-store/build.gradle.kts
+++ b/entity-store/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     api(project(":xodus-openAPI"))
-    api("io.youtrackdb:youtrackdb-core:1.0.0-20250423.081223-29")
+    api("io.youtrackdb:youtrackdb-core:1.0.0-20250425.055051-30")
 
     implementation(project(":xodus-utils"))
     implementation(project(":xodus-environment"))

--- a/entity-store/build.gradle.kts
+++ b/entity-store/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     api(project(":xodus-openAPI"))
-    api("io.youtrackdb:youtrackdb-core:1.0.0-20250416.175118-26")
+    api("io.youtrackdb:youtrackdb-core:1.0.0-20250417.140435-27")
 
     implementation(project(":xodus-utils"))
     implementation(project(":xodus-environment"))

--- a/entity-store/build.gradle.kts
+++ b/entity-store/build.gradle.kts
@@ -1,7 +1,6 @@
 dependencies {
     api(project(":xodus-openAPI"))
-    api("io.youtrackdb:youtrackdb-core:1.0.0-20250411.103608-22")
-//    api("io.youtrackdb:youtrackdb-core:1.0.0-20250415.063407-24")
+    api("io.youtrackdb:youtrackdb-core:1.0.0-20250415.152546-25")
 
     implementation(project(":xodus-utils"))
     implementation(project(":xodus-environment"))

--- a/entity-store/build.gradle.kts
+++ b/entity-store/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     api(project(":xodus-openAPI"))
-    api("io.youtrackdb:youtrackdb-core:1.0.0-20250226.144437-20")
+    api("io.youtrackdb:youtrackdb-core:1.0.0-20250411.103608-22")
+//    api("io.youtrackdb:youtrackdb-core:1.0.0-20250415.063407-24")
 
     implementation(project(":xodus-utils"))
     implementation(project(":xodus-environment"))

--- a/entity-store/build.gradle.kts
+++ b/entity-store/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     api(project(":xodus-openAPI"))
-    api("io.youtrackdb:youtrackdb-core:1.0.0-20250417.140435-27")
+    api("io.youtrackdb:youtrackdb-core:1.0.0-20250423.081223-29")
 
     implementation(project(":xodus-utils"))
     implementation(project(":xodus-environment"))

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityId.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityId.kt
@@ -25,7 +25,7 @@ class RIDEntityId(
     private val classId: Int,
     private val localEntityId: Long,
     private val oId: RID,
-    private val schemaClass: SchemaClass?
+    private val schemaClassName: String?
 ) : YTDBEntityId {
 
     companion object {
@@ -37,7 +37,7 @@ class RIDEntityId(
             val oClass = vertex.requireSchemaClass()
             val classId = oClass.requireClassId()
             val localEntityId = vertex.requireLocalEntityId()
-            return RIDEntityId(classId, localEntityId, vertex.identity, oClass)
+            return RIDEntityId(classId, localEntityId, vertex.identity, oClass.name)
         }
     }
 
@@ -50,7 +50,7 @@ class RIDEntityId(
     }
 
     override fun getTypeName(): String {
-        return schemaClass?.name ?: "typeNotFound"
+        return schemaClassName ?: "typeNotFound"
     }
 
     override fun getLocalId(): Long {

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityId.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityId.kt
@@ -61,7 +61,12 @@ class RIDEntityId(
         if (other !is RIDEntityId) {
             throw IllegalArgumentException("Cannot compare ORIDEntityId with ${other?.javaClass?.name}")
         }
-        return oId.compareTo(other.oId)
+        val classCompare = classId.compareTo(other.classId)
+        if (classCompare == 0) {
+            return localEntityId.compareTo(other.localEntityId);
+        } else {
+            return classCompare;
+        }
     }
 
     override fun toString(): String {

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBComparableSet.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBComparableSet.kt
@@ -15,12 +15,12 @@
  */
 package jetbrains.exodus.entitystore.youtrackdb
 
-import com.jetbrains.youtrack.db.internal.core.db.record.TrackedSet
+import com.jetbrains.youtrack.db.internal.core.db.record.TrackedMultiValue
 
 class YTDBComparableSet<E>(val source: MutableSet<E>) : MutableSet<E> by source, Comparable<MutableSet<E>> {
     val isDirty: Boolean
         get() {
-            return if (source is TrackedSet) {
+            return if (source is TrackedMultiValue<*, *>) {
                 source.isTransactionModified
             } else {
                 true

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseParams.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseParams.kt
@@ -45,7 +45,6 @@ class YTDBDatabaseParams private constructor(
     val youTrackDBConfig: YouTrackDBConfig = YouTrackDBConfig.builder()
         .addGlobalConfigurationParameter(GlobalConfiguration.AUTO_CLOSE_AFTER_DELAY, true)
         .addGlobalConfigurationParameter(GlobalConfiguration.AUTO_CLOSE_DELAY, closeAfterDelayTimeout)
-        .addGlobalConfigurationParameter(GlobalConfiguration.NON_TX_READS_WARNING_MODE, "SILENT")
         .apply {
             encryptionKey?.let { addGlobalConfigurationParameter(GlobalConfiguration.STORAGE_ENCRYPTION_KEY, it) }
         }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
@@ -24,18 +24,6 @@ interface YTDBDatabaseProvider {
     fun acquireSession(): DatabaseSession
 
     /**
-     * If there is a session on the current thread, create a new session, executes the action in it,
-     * and returns the previous session back to the current thread.
-     *
-     * Never use this method. If you use this method, make sure you 100% understand what happens,
-     * and do not hesitate to invite people to review your code.
-     */
-    fun <T> executeInASeparateSession(
-        currentSession: DatabaseSession,
-        action: (DatabaseSession) -> T
-    ): T
-
-    /**
      * Database-wise read-only mode.
      * Always false by default.
      */
@@ -86,9 +74,9 @@ internal fun DatabaseSession.hasActiveTransaction(): Boolean {
     return (this as DatabaseSessionInternal).isActiveOnCurrentThread && activeTxCount() > 0
 }
 
-internal fun DatabaseSession.requireActiveTransaction() {
-    require(hasActiveTransaction()) { "No active transaction is found. Happy debugging, pal!" }
-}
+//internal fun DatabaseSession.requireActiveTransaction() {
+//    require(hasActiveTransaction()) { "No active transaction is found. Happy debugging, pal!" }
+//}
 
 internal fun DatabaseSession.requireNoActiveTransaction() {
     assert((this as DatabaseSessionInternal).isActiveOnCurrentThread && activeTxCount() == 0) { "Active transaction is detected. Changes in the schema must not happen in a transaction." }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
@@ -40,58 +40,10 @@ fun <R> YTDBDatabaseProvider.withSession(block: (DatabaseSession) -> R): R {
     }
 }
 
-//fun <R> YTDBDatabaseProvider.withCurrentOrNewSession(
-//    requireNoActiveTransaction: Boolean = false,
-//    block: (DatabaseSession) -> R
-//): R {
-//    return if (hasActiveSession()) {
-//        val activeSession = DatabaseRecordThreadLocal.instance().getIfDefined() as DatabaseSession
-//        if (requireNoActiveTransaction) {
-//            if (activeSession.isTxActive) {
-//                val copy = (activeSession as DatabaseSessionInternal).copy()
-//                copy.activateOnCurrentThread()
-//                try {
-//                    copy.use {
-//                        block(copy)
-//                    }
-//                } finally {
-//                    activeSession.activateOnCurrentThread()
-//                }
-//            } else {
-//                block(activeSession)
-//            }
-//        } else {
-//            block(activeSession)
-//        }
-//    } else {
-//        withSession { newSession ->
-//            block(newSession)
-//        }
-//    }
-//}
-
 internal fun DatabaseSession.hasActiveTransaction(): Boolean {
     return (this as DatabaseSessionInternal).isActiveOnCurrentThread && activeTxCount() > 0
 }
 
-//internal fun DatabaseSession.requireActiveTransaction() {
-//    require(hasActiveTransaction()) { "No active transaction is found. Happy debugging, pal!" }
-//}
-
 internal fun DatabaseSession.requireNoActiveTransaction() {
     assert((this as DatabaseSessionInternal).isActiveOnCurrentThread && activeTxCount() == 0) { "Active transaction is detected. Changes in the schema must not happen in a transaction." }
 }
-
-fun <R> DatabaseSession.transaction(fn: (Transaction) -> R) {
-    computeInTx<R, Nothing>(fn)
-}
-
-//
-//internal fun requireNoActiveSession() {
-//    check(!hasActiveSession()) { "Active session is detected on the current thread" }
-//}
-//
-//internal fun hasActiveSession(): Boolean {
-//    val db = DatabaseRecordThreadLocal.instance().getIfDefined()
-//    return db != null
-//}

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProvider.kt
@@ -16,6 +16,7 @@
 package jetbrains.exodus.entitystore.youtrackdb
 
 import com.jetbrains.youtrack.db.api.DatabaseSession
+import com.jetbrains.youtrack.db.api.transaction.Transaction
 import com.jetbrains.youtrack.db.internal.core.db.DatabaseSessionInternal
 
 interface YTDBDatabaseProvider {
@@ -92,6 +93,11 @@ internal fun DatabaseSession.requireActiveTransaction() {
 internal fun DatabaseSession.requireNoActiveTransaction() {
     assert((this as DatabaseSessionInternal).isActiveOnCurrentThread && activeTxCount() == 0) { "Active transaction is detected. Changes in the schema must not happen in a transaction." }
 }
+
+fun <R> DatabaseSession.transaction(fn: (Transaction) -> R) {
+    computeInTx<R, Nothing>(fn)
+}
+
 //
 //internal fun requireNoActiveSession() {
 //    check(!hasActiveSession()) { "Active session is detected on the current thread" }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
@@ -17,6 +17,7 @@ package jetbrains.exodus.entitystore.youtrackdb
 
 import com.jetbrains.youtrack.db.api.DatabaseSession
 import com.jetbrains.youtrack.db.api.YouTrackDB
+import com.jetbrains.youtrack.db.internal.core.db.DatabaseSessionInternal
 import java.io.File
 
 //username and password are considered to be same for all databases
@@ -69,7 +70,7 @@ class YTDBDatabaseProviderImpl(
             }
         } finally {
             // the previous session does not get activated on the current thread by default
-            assert(!currentSession.isActiveOnCurrentThread)
+            assert(!(currentSession as DatabaseSessionInternal).isActiveOnCurrentThread)
             currentSession.activateOnCurrentThread()
         }
         return result
@@ -82,7 +83,7 @@ class YTDBDatabaseProviderImpl(
         get() = _readOnly
         set(value) {
             if (_readOnly == value) return
-            requireNoActiveSession()
+//            requireNoActiveSession()
 
             withSession { session ->
                 if (value) {
@@ -96,9 +97,9 @@ class YTDBDatabaseProviderImpl(
         }
 
     private fun acquireSessionImpl(checkNoActiveSession: Boolean = true): DatabaseSession {
-        if (checkNoActiveSession) {
-            requireNoActiveSession()
-        }
+//        if (checkNoActiveSession) {
+//            requireNoActiveSession()
+//        }
         return database.cachedPool(
             params.databaseName,
             params.userName,

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
@@ -60,22 +60,6 @@ class YTDBDatabaseProviderImpl(
         return acquireSessionImpl(true)
     }
 
-    override fun <T> executeInASeparateSession(
-        currentSession: DatabaseSession,
-        action: (DatabaseSession) -> T
-    ): T {
-        val result = try {
-            acquireSessionImpl(checkNoActiveSession = false).use { session ->
-                action(session)
-            }
-        } finally {
-            // the previous session does not get activated on the current thread by default
-            assert(!(currentSession as DatabaseSessionInternal).isActiveOnCurrentThread)
-            currentSession.activateOnCurrentThread()
-        }
-        return result
-    }
-
     // it is always false at the beginning (it is impossible to close the database in the frozen state)
     private var _readOnly: Boolean = false
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
@@ -57,7 +57,7 @@ class YTDBDatabaseProviderImpl(
         get() = File(params.databasePath, params.databaseName).absolutePath
 
     override fun acquireSession(): DatabaseSession {
-        return acquireSessionImpl(true)
+        return acquireSessionImpl()
     }
 
     // it is always false at the beginning (it is impossible to close the database in the frozen state)
@@ -67,7 +67,6 @@ class YTDBDatabaseProviderImpl(
         get() = _readOnly
         set(value) {
             if (_readOnly == value) return
-//            requireNoActiveSession()
 
             withSession { session ->
                 if (value) {
@@ -80,10 +79,7 @@ class YTDBDatabaseProviderImpl(
             _readOnly = value
         }
 
-    private fun acquireSessionImpl(checkNoActiveSession: Boolean = true): DatabaseSession {
-//        if (checkNoActiveSession) {
-//            requireNoActiveSession()
-//        }
+    private fun acquireSessionImpl(): DatabaseSession {
         return database.cachedPool(
             params.databaseName,
             params.userName,

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBEntity.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBEntity.kt
@@ -21,8 +21,6 @@ interface YTDBEntity : Entity {
 
     override fun getId(): YTDBEntityId
 
-    fun save(): YTDBEntity
-
     fun resetToNew()
 
     fun generateId()

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
@@ -132,14 +132,9 @@ class YTDBPersistentEntityStore(
             tx.commit()
             return result
         } finally {
-//            try {
-                if (!tx.isFinished) {
-                    tx.abort()
-                }
-//            } catch (e: Throwable) {
-//                println("Error while calling abort on transaction $tx: ${e.message}")
-//                e.printStackTrace()
-//            }
+            if (!tx.isFinished) {
+                tx.abort()
+            }
         }
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
@@ -21,6 +21,7 @@ import jetbrains.exodus.backup.BackupStrategy
 import jetbrains.exodus.bindings.ComparableBinding
 import jetbrains.exodus.entitystore.*
 import mu.withLoggingContext
+import javax.xml.crypto.Data
 
 class YTDBPersistentEntityStore(
     private val databaseProvider: YTDBDatabaseProvider,
@@ -103,7 +104,7 @@ class YTDBPersistentEntityStore(
 //        check(!hasActiveSession()) { "There is an active session on the current thread" }
         check(!tx.isFinished) { "Cannot activate a finished transaction" }
         check(!session.isClosed) { "Cannot activate a closed session" }
-        (session as DatabaseSessionInternal).activateOnCurrentThread()
+//        (session as DatabaseSessionInternal).activateOnCurrentThread()
         currentTransaction.set(tx)
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBPersistentEntityStore.kt
@@ -96,15 +96,12 @@ class YTDBPersistentEntityStore(
         check(!tx.isFinished) { "Cannot deactivate a finished transaction" }
         check(!session.isClosed) { "Cannot deactivate a closed session" }
         currentTransaction.remove()
-//        DatabaseRecordThreadLocal.instance().remove()
     }
 
     private fun onTransactionActivated(session: DatabaseSession, tx: YTDBStoreTransaction) {
         check(currentTransaction.get() == null) { "Impossible to activate the transaction. There is already an active transaction on the current thread." }
-//        check(!hasActiveSession()) { "There is an active session on the current thread" }
         check(!tx.isFinished) { "Cannot activate a finished transaction" }
         check(!session.isClosed) { "Cannot activate a closed session" }
-//        (session as DatabaseSessionInternal).activateOnCurrentThread()
         currentTransaction.set(tx)
     }
 
@@ -135,14 +132,14 @@ class YTDBPersistentEntityStore(
             tx.commit()
             return result
         } finally {
-            try {
+//            try {
                 if (!tx.isFinished) {
                     tx.abort()
                 }
-            } catch (e: Throwable) {
-                println("Error while calling abort on transaction $tx: ${e.message}")
-                e.printStackTrace()
-            }
+//            } catch (e: Throwable) {
+//                println("Error while calling abort on transaction $tx: ${e.message}")
+//                e.printStackTrace()
+//            }
         }
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBSchemaBuddy.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBSchemaBuddy.kt
@@ -199,7 +199,7 @@ class YTDBSchemaBuddyImpl(
             return RIDEntityId.EMPTY_ID
         }
 
-        return RIDEntityId(classId, localEntityId, oid, oClass)
+        return RIDEntityId(classId, localEntityId, oid, oClass.name)
     }
 
     override fun getTypeId(session: DatabaseSession, entityType: String): Int {

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransaction.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransaction.kt
@@ -21,6 +21,7 @@ import com.jetbrains.youtrack.db.api.record.DBRecord
 import com.jetbrains.youtrack.db.api.record.Vertex
 import com.jetbrains.youtrack.db.api.schema.SchemaClass
 import com.jetbrains.youtrack.db.internal.core.metadata.sequence.DBSequence
+import com.jetbrains.youtrack.db.internal.core.tx.FrontendTransaction
 import jetbrains.exodus.entitystore.PersistentEntityId
 import jetbrains.exodus.entitystore.StoreTransaction
 
@@ -31,9 +32,9 @@ interface YTDBStoreTransaction : StoreTransaction {
 
     fun getTransactionId(): Long
 
-    fun requireActiveTransaction()
+    fun requireActiveTransaction(): FrontendTransaction
 
-    fun requireActiveWritableTransaction()
+    fun requireActiveWritableTransaction(): FrontendTransaction
 
     fun deactivateOnCurrentThread()
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
@@ -241,11 +241,12 @@ class YTDBStoreTransactionImpl(
     override fun getEntity(id: EntityId): Entity {
         val tx = requireActiveTransaction()
         val oId = store.requireOEntityId(id)
-        if (oId == RIDEntityId.EMPTY_ID) {
+        val ytdbId = oId.asOId()
+        if (ytdbId == ImmutableRecordId.EMPTY_RECORD_ID) {
             throw EntityRemovedInDatabaseException(oId.getTypeName(), id)
         }
         try {
-            val vertex: Vertex = tx.load(oId.asOId())
+            val vertex: Vertex = tx.load(ytdbId)
             return YTDBVertexEntity(vertex, store)
         } catch (_: RecordNotFoundException) {
             throw EntityRemovedInDatabaseException(oId.getTypeName(), id)

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
@@ -132,7 +132,6 @@ class YTDBStoreTransactionImpl(
 
     override fun activateOnCurrentThread() {
         check(session.status == DatabaseSession.STATUS.OPEN) { "The transaction is finished, the internal session state: ${session.status}" }
-//        check(!(session as DatabaseSessionInternal).isActiveOnCurrentThread) { "The transaction is already active on the current thread" }
         onActivated(session, this)
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
@@ -132,7 +132,7 @@ class YTDBStoreTransactionImpl(
 
     override fun activateOnCurrentThread() {
         check(session.status == DatabaseSession.STATUS.OPEN) { "The transaction is finished, the internal session state: ${session.status}" }
-        check(!(session as DatabaseSessionInternal).isActiveOnCurrentThread) { "The transaction is already active on the current thread" }
+//        check(!(session as DatabaseSessionInternal).isActiveOnCurrentThread) { "The transaction is already active on the current thread" }
         onActivated(session, this)
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBVertexEntity.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBVertexEntity.kt
@@ -343,7 +343,7 @@ open class YTDBVertexEntity(vertex: Vertex, private val store: YTDBEntityStore) 
          */
         val currentEdge: Edge? =
             if ((edgeClass as SchemaClassInternal).areIndexed(
-                    databaseSession as DatabaseSessionInternal,
+                    vertex.boundedToSession as DatabaseSessionInternal,
                     Edge.DIRECTION_IN,
                     Edge.DIRECTION_OUT
                 )

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/link/YTDBVertexEntityIterable.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/link/YTDBVertexEntityIterable.kt
@@ -45,7 +45,7 @@ class YTDBVertexEntityIterable(
         override fun skip(number: Int) =
             (0 until number).count { iterator.hasNext() }.also { iterator.next() } == number
 
-        override fun nextId() = iterator.next().run { PersistentEntityId(identity.clusterId, identity.clusterPosition) }
+        override fun nextId() = iterator.next().run { PersistentEntityId(identity.collectionId, identity.collectionPosition) }
 
         override fun dispose() = true
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/property/YTDBSequenceImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/property/YTDBSequenceImpl.kt
@@ -15,20 +15,22 @@
  */
 package jetbrains.exodus.entitystore.youtrackdb.iterate.property
 
+import com.jetbrains.youtrack.db.internal.core.db.DatabaseSessionInternal
 import com.jetbrains.youtrack.db.internal.core.metadata.sequence.DBSequence
 import jetbrains.exodus.entitystore.Sequence
 import jetbrains.exodus.entitystore.youtrackdb.YTDBPersistentEntityStore
 
 internal class YTDBSequenceImpl(
+    private val session: DatabaseSessionInternal,
     private val sequenceName: String,
     private val store: YTDBPersistentEntityStore
 ) : Sequence {
     override fun increment(): Long {
-        return getOSequence().next()
+        return getOSequence().next(session)
     }
 
     override fun get(): Long {
-        return getOSequence().current()
+        return getOSequence().current(session)
     }
 
     override fun set(l: Long) {

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryExecution.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryExecution.kt
@@ -28,8 +28,8 @@ object YTDBQueryExecution : KLogging() {
         // Log execution plan
         // ToDo: add System param to enable/disable logging of execution plan
         logger.debug {
-            val executionPlan = resultSet.executionPlan.get().prettyPrint(10, 8)
-            "Query: $sqlQuery, \n execution plan:\n  $executionPlan, \n stats: ${resultSet.queryStats}"
+            val executionPlan = resultSet.executionPlan!!.prettyPrint(10, 8)
+            "Query: $sqlQuery, \n execution plan:\n  $executionPlan"
         }
         tx.bindResultSet(resultSet)
         return resultSet

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryFunctions.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryFunctions.kt
@@ -124,7 +124,7 @@ class YTDBCountSelect(
         builder.append(")")
     }
 
-    fun count(tx: YTDBStoreTransaction): Long = YTDBQueryExecution.execute(this, tx).next().getProperty("count")
+    fun count(tx: YTDBStoreTransaction): Long = YTDBQueryExecution.execute(this, tx).next().getLong("count")!!
 }
 
 class YTDBFirstSelect(

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/EncryptedDBTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/EncryptedDBTest.kt
@@ -53,7 +53,7 @@ class EncryptedDBTest(val number: Int) {
             .withDatabasePath(databasePath)
             .withPassword(password)
             .withUserName(username)
-            .withDatabaseType(DatabaseType.PLOCAL)
+            .withDatabaseType(DatabaseType.DISK)
             .withDatabaseName(dbName)
             .withCloseDatabaseInDbProvider(true)
             .apply { encryptionKey?.let { withEncryptionKey(it) } }
@@ -75,13 +75,12 @@ class EncryptedDBTest(val number: Int) {
 
         provider = YTDBDatabaseProviderFactory.createProvider(params)
         provider.withSession { session ->
-            session.createVertexClass("TEST")
+            session.schema.createVertexClass("TEST")
         }
         provider.withSession { session ->
-            session.executeInTx {
-                val vertex = session.newVertex("TEST")
+            session.executeInTx { tx ->
+                val vertex = tx.newVertex("TEST")
                 vertex.setProperty("hello", "world")
-                vertex.save()
             }
         }
         provider.close()
@@ -91,8 +90,8 @@ class EncryptedDBTest(val number: Int) {
         logger.info("Connect to db one more time and read")
         provider = YTDBDatabaseProviderFactory.createProvider(params)
         provider.withSession { session ->
-            session.executeInTx {
-                val vertex = session.query("SELECT FROM TEST").vertexStream().toList()
+            session.executeInTx { tx ->
+                val vertex = tx.query("SELECT FROM TEST").vertexStream().toList()
                 Assert.assertEquals(1, vertex.size)
             }
         }
@@ -104,8 +103,8 @@ class EncryptedDBTest(val number: Int) {
         provider = YTDBDatabaseProviderFactory.createProvider(noEncryptionParams)
         try {
             provider.withSession { session ->
-                session.executeInTx {
-                    val vertex = session.query("SELECT FROM TEST").vertexStream().toList()
+                session.executeInTx { tx ->
+                    val vertex = tx.query("SELECT FROM TEST").vertexStream().toList()
                     print(vertex.size)
                 }
             }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/EncryptedDBTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/EncryptedDBTest.kt
@@ -78,7 +78,7 @@ class EncryptedDBTest(val number: Int) {
             session.schema.createVertexClass("TEST")
         }
         provider.withSession { session ->
-            session.executeInTx { tx ->
+            session.transaction { tx ->
                 val vertex = tx.newVertex("TEST")
                 vertex.setProperty("hello", "world")
             }
@@ -90,7 +90,7 @@ class EncryptedDBTest(val number: Int) {
         logger.info("Connect to db one more time and read")
         provider = YTDBDatabaseProviderFactory.createProvider(params)
         provider.withSession { session ->
-            session.executeInTx { tx ->
+            session.transaction { tx ->
                 val vertex = tx.query("SELECT FROM TEST").vertexStream().toList()
                 Assert.assertEquals(1, vertex.size)
             }
@@ -103,7 +103,7 @@ class EncryptedDBTest(val number: Int) {
         provider = YTDBDatabaseProviderFactory.createProvider(noEncryptionParams)
         try {
             provider.withSession { session ->
-                session.executeInTx { tx ->
+                session.transaction { tx ->
                     val vertex = tx.query("SELECT FROM TEST").vertexStream().toList()
                     print(vertex.size)
                 }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityIdTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityIdTest.kt
@@ -32,25 +32,23 @@ class RIDEntityIdTest {
     @Test
     fun `require both classId and localEntityId to create an instance`() {
         val oClass = youTrackDb.provider.withSession { oSession ->
-            oSession.createVertexClass("type1")
+            oSession.schema.createVertexClass("type1")
         }
         var vertex: Vertex = youTrackDb.withTxSession { oSession ->
-            val v = oSession.newVertex(oClass)
-            v.save()
-            v
+            oSession.activeTransaction.newVertex(oClass)
         }
         youTrackDb.withTxSession {
             assertFailsWith<IllegalStateException> {
-                vertex = it.bindToSession(vertex)
+                vertex = it.activeTransaction.loadVertex(vertex)
                 RIDEntityId.fromVertex(vertex)
             }
         }
 
         youTrackDb.provider.withSession {
-            oClass.setCustom(it, YTDBVertexEntity.CLASS_ID_CUSTOM_PROPERTY_NAME, 300.toString())
+            oClass.setCustom(YTDBVertexEntity.CLASS_ID_CUSTOM_PROPERTY_NAME, 300.toString())
         }
         youTrackDb.withTxSession {
-            vertex = it.bindToSession(vertex)
+            vertex = it.activeTransaction.loadVertex(vertex)
             assertFailsWith<IllegalStateException> {
                 RIDEntityId.fromVertex(vertex)
             }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityIdTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/RIDEntityIdTest.kt
@@ -31,11 +31,11 @@ class RIDEntityIdTest {
 
     @Test
     fun `require both classId and localEntityId to create an instance`() {
-        val oClass = youTrackDb.provider.withSession { oSession ->
+        youTrackDb.provider.withSession { oSession ->
             oSession.schema.createVertexClass("type1")
         }
         var vertex: Vertex = youTrackDb.withTxSession { oSession ->
-            oSession.activeTransaction.newVertex(oClass)
+            oSession.activeTransaction.newVertex("type1")
         }
         youTrackDb.withTxSession {
             assertFailsWith<IllegalStateException> {
@@ -44,7 +44,8 @@ class RIDEntityIdTest {
             }
         }
 
-        youTrackDb.provider.withSession {
+        youTrackDb.provider.withSession { oSession ->
+            val oClass = oSession.schema.getClass("type1")
             oClass.setCustom(YTDBVertexEntity.CLASS_ID_CUSTOM_PROPERTY_NAME, 300.toString())
         }
         youTrackDb.withTxSession {

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderTest.kt
@@ -34,22 +34,19 @@ class YTDBDatabaseProviderTest: OTestMixin {
     fun `read-only mode works`() {
         // by default it is read-write
         withTxSession { session ->
-            val v = session.newVertex()
-            v.save()
+            session.activeTransaction.newVertex()
         }
 
         youTrackDb.provider.readOnly = true
         assertFailsWith<ModificationOperationProhibitedException> {
             withTxSession { session ->
-                val v = session.newVertex()
-                v.save()
+                session.activeTransaction.newVertex()
             }
         }
 
         youTrackDb.provider.readOnly = false
         withTxSession { session ->
-            val v = session.newVertex()
-            v.save()
+            session.activeTransaction.newVertex()
         }
 
         youTrackDb.provider.readOnly = true

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBEntityTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBEntityTest.kt
@@ -111,7 +111,7 @@ class YTDBEntityTest : OTestMixin {
         val issueC = youTrackDb.createIssue("C")
         val linkName = "link"
         youTrackDb.withSession { session ->
-            session.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
         }
 
         youTrackDb.withStoreTx {
@@ -301,11 +301,10 @@ class YTDBEntityTest : OTestMixin {
     fun `delete links`() {
         val linkName = "link"
         youTrackDb.withSession { session ->
-            session.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
-            val oClass = session.getClass(Issues.CLASS)!!
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+            val oClass = session.schema.getClass(Issues.CLASS)!!
             // pretend that the link is indexed
             oClass.createProperty(
-                session,
                 linkTargetEntityIdPropertyName(linkName),
                 PropertyType.LINKBAG
             )
@@ -340,11 +339,10 @@ class YTDBEntityTest : OTestMixin {
     fun `set links`() {
         val linkName = "link"
         youTrackDb.withSession { session ->
-            session.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
-            val oClass = session.getClass(Issues.CLASS)!!
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+            val oClass = session.schema.getClass(Issues.CLASS)!!
             // pretend that the link is indexed
             oClass.createProperty(
-                session,
                 linkTargetEntityIdPropertyName(linkName),
                 PropertyType.LINKBAG
             )
@@ -388,11 +386,10 @@ class YTDBEntityTest : OTestMixin {
     fun `should delete all links`() {
         val linkName = "link"
         youTrackDb.withSession { session ->
-            session.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
-            val oClass = session.getClass(Issues.CLASS)!!
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+            val oClass = session.schema.getClass(Issues.CLASS)!!
             // pretend that the link is indexed
             oClass.createProperty(
-                session,
                 linkTargetEntityIdPropertyName(linkName),
                 PropertyType.LINKBAG
             )
@@ -421,7 +418,7 @@ class YTDBEntityTest : OTestMixin {
     fun `should replace a link correctly`() {
         val linkName = "link"
         youTrackDb.withSession { session ->
-            session.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
         }
 
         val issueA = youTrackDb.createIssue("A")
@@ -446,7 +443,7 @@ class YTDBEntityTest : OTestMixin {
     fun `setLink() and addLink() should work correctly with PersistentEntityId`() {
         val linkName = "link"
         youTrackDb.withSession { session ->
-            session.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
         }
 
         val issueA = youTrackDb.createIssue("A")
@@ -473,7 +470,7 @@ class YTDBEntityTest : OTestMixin {
     fun `setLink() and addLink() return false if the target entity is not found`() {
         val linkName = "link"
         youTrackDb.withSession { session ->
-            session.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
+            session.schema.createEdgeClass(YTDBVertexEntity.edgeClassName(linkName))
         }
 
         val issueB = youTrackDb.createIssue("A")

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBSchemaBuddyTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBSchemaBuddyTest.kt
@@ -56,7 +56,7 @@ class YTDBSchemaBuddyTest : OTestMixin {
             buddy.initialize(it)
         }
 
-        withSession {
+        withTxSession {
             assertEquals(issueId, buddy.getOEntityId(it, totallyExistingEntityId))
         }
     }
@@ -85,7 +85,7 @@ class YTDBSchemaBuddyTest : OTestMixin {
         val partiallyExistingEntityId1 = PersistentEntityId(issueId.typeId, 301)
         val partiallyExistingEntityId2 = PersistentEntityId(300, issueId.localId)
         val totallyExistingEntityId = PersistentEntityId(issueId.typeId, issueId.localId)
-        withSession {
+        withTxSession {
             assertEquals(RIDEntityId.EMPTY_ID, buddy.getOEntityId(it, notExistingEntityId))
             assertEquals(RIDEntityId.EMPTY_ID, buddy.getOEntityId(it, partiallyExistingEntityId1))
             assertEquals(RIDEntityId.EMPTY_ID, buddy.getOEntityId(it, partiallyExistingEntityId2))
@@ -149,17 +149,17 @@ class YTDBSchemaBuddyTest : OTestMixin {
         }
 
         // the changes made in the transaction are still there
-        withSession { session ->
+        withTxSession { session ->
             assertNotNull(session.activeTransaction.loadVertex(issId))
         }
     }
 
     @Test
     fun `require both classId and localEntityId to create an instance`() {
-        val oClass = youTrackDb.provider.withSession { oSession ->
-            oSession.createVertexClassWithClassId("type1")
+        val typeID = youTrackDb.provider.withSession { oSession ->
+            val oClass = oSession.createVertexClassWithClassId("type1")
+            oClass.requireClassId()
         }
-        val typeID = oClass.requireClassId()
         youTrackDb.provider.withSession { oSession ->
             assertEquals("type1", youTrackDb.schemaBuddy.getType(oSession, typeID))
         }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBSequenceImplTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBSequenceImplTest.kt
@@ -83,7 +83,7 @@ class YTDBSequenceImplTest : OTestMixin {
                 "s1",
                 DBSequence.SEQUENCE_TYPE.ORDERED, DBSequence.CreateParams().setStart(300).setIncrement(1)
             )
-            assertFailsWith<RecordNotFoundException> { seq.current() }
+            assertFailsWith<RecordNotFoundException> { seq.current(session) }
         }
     }
 }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBSequenceImplTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBSequenceImplTest.kt
@@ -48,14 +48,16 @@ class YTDBSequenceImplTest : OTestMixin {
 
     @Test
     fun `sequence may be created in one session and used in another`() {
-        val seq: Sequence = youTrackDb.store.computeInTransaction { tx ->
+        youTrackDb.store.computeInTransaction { tx ->
             tx.getSequence("s1", 300)
         }
         youTrackDb.store.executeInTransaction {
+            val seq: Sequence = it.getSequence("s1")
             Assert.assertEquals(300, seq.get())
             Assert.assertEquals(301, seq.increment())
         }
         youTrackDb.store.executeInTransaction {
+            val seq: Sequence = it.getSequence("s1")
             Assert.assertEquals(301, seq.get())
             Assert.assertEquals(302, seq.increment())
         }
@@ -63,13 +65,14 @@ class YTDBSequenceImplTest : OTestMixin {
 
     @Test
     fun `sequence_set() resets the current value`() {
-        val seq = youTrackDb.store.computeInTransaction { tx ->
+        youTrackDb.store.computeInTransaction { tx ->
             val seq = tx.getSequence("s1", 300)
             Assert.assertEquals(300, seq.get())
             Assert.assertEquals(301, seq.increment())
             seq
         }
         youTrackDb.store.executeInTransaction {
+            val seq: Sequence = it.getSequence("s1")
             seq.set(200)
             Assert.assertEquals(200, seq.get())
             Assert.assertEquals(201, seq.increment())

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionLifecycleTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionLifecycleTest.kt
@@ -97,8 +97,8 @@ class YTDBStoreTransactionLifecycleTest : OTestMixin {
     fun `commit() and flush() finish the transaction if error happens`() {
         val session = youTrackDb.openSession()
         val oClass = session.getOrCreateVertexClass("trista")
-        oClass.createProperty(session, "name", PropertyType.STRING)
-        oClass.createIndex(session, "idx_name", SchemaClass.INDEX_TYPE.UNIQUE, "name")
+        oClass.createProperty("name", PropertyType.STRING)
+        oClass.createIndex("idx_name", SchemaClass.INDEX_TYPE.UNIQUE, "name")
         session.close()
 
 
@@ -106,12 +106,10 @@ class YTDBStoreTransactionLifecycleTest : OTestMixin {
             val tx = beginTransaction()
 
 
-            val trista1 = tx.databaseSession.newVertex("trista")
+            val trista1 = tx.databaseSession.activeTransaction.newVertex("trista")
             trista1.setProperty("name", "dvesti")
-            trista1.save()
-            val trista2 = tx.databaseSession.newVertex("trista")
+            val trista2 = tx.databaseSession.activeTransaction.newVertex("trista")
             trista2.setProperty("name", "dvesti")
-            trista2.save()
 
             when (actionName) {
                 "commit",

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionTest.kt
@@ -491,10 +491,10 @@ class YTDBStoreTransactionTest : OTestMixin {
             val issuesAsc = tx.sortLinks(
                 Issues.CLASS, // entity class
                 tx.sort(Projects.CLASS, "name", links, false), // links sorted desc by name
-                false, // is multiple
+                true, // is multiple
                 Issues.Links.IN_PROJECT, // link name
                 issues // entities
-            ).distinct()
+            )
 
             // Then
             assertNamesExactlyInOrder(issuesAsc, "issue3", "issue2", "issue1")

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionTest.kt
@@ -52,7 +52,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val issues = tx.getAll(Issues.CLASS)
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue1", "issue2", "issue3")
+            assertNamesExactly(issues, "issue1", "issue2", "issue3")
         }
     }
 
@@ -66,7 +66,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val result = tx.find(Issues.CLASS, "name", "issue2")
 
             // Then
-            assertNamesExactlyInOrder(result, "issue2")
+            assertNamesExactly(result, "issue2")
         }
     }
 
@@ -113,7 +113,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val empty = tx.findContaining(Issues.CLASS, "case", "not", true)
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue2")
+            assertNamesExactly(issues, "issue2")
             assertThat(empty).isEmpty()
         }
     }
@@ -130,7 +130,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val empty = tx.findStartingWith(Issues.CLASS, "case", "you")
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue2")
+            assertNamesExactly(issues, "issue2")
             assertThat(empty).isEmpty()
         }
     }
@@ -151,9 +151,9 @@ class YTDBStoreTransactionTest : OTestMixin {
             val empty = tx.find(Issues.CLASS, "value", 6, 12)
 
             // Then
-            assertNamesExactlyInOrder(exclusive, "issue2")
-            assertNamesExactlyInOrder(inclusiveMin, "issue2")
-            assertNamesExactlyInOrder(inclusiveMax, "issue2")
+            assertNamesExactly(exclusive, "issue2")
+            assertNamesExactly(inclusiveMin, "issue2")
+            assertNamesExactly(inclusiveMax, "issue2")
             assertThat(empty).isEmpty()
         }
     }
@@ -171,7 +171,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val empty = tx.findWithProp(Issues.CLASS, "no_prop")
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue2")
+            assertNamesExactly(issues, "issue2")
             assertThat(empty).isEmpty()
         }
     }
@@ -197,7 +197,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val issues = tx.findWithBlob(Issues.CLASS, "myBlob")
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue1", "issue2", "issue3")
+            assertNamesExactly(issues, "issue1", "issue2", "issue3")
         }
     }
 
@@ -303,7 +303,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val issues = tx.findLinks(Issues.CLASS, testCase.project1, Issues.Links.IN_PROJECT)
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue1", "issue2")
+            assertNamesExactly(issues, "issue1", "issue2")
         }
     }
 
@@ -324,7 +324,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val issues = tx.findLinks(Issues.CLASS, projects, Issues.Links.IN_PROJECT)
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue1", "issue2", "issue3")
+            assertNamesExactly(issues, "issue1", "issue2", "issue3")
         }
     }
 
@@ -344,7 +344,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val issuesInProject = tx.findWithLinks(Issues.CLASS, Issues.Links.IN_PROJECT)
 
             // Then
-            assertNamesExactlyInOrder(issuesOnBoard, "issue1", "issue2")
+            assertNamesExactly(issuesOnBoard, "issue1", "issue2")
             assertThat(issuesInProject).isEmpty()
         }
     }
@@ -370,7 +370,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val issues = issuesInProject1.union(issuesInProject2)
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue1", "issue2", "issue3")
+            assertNamesExactly(issues, "issue1", "issue2", "issue3")
         }
     }
 
@@ -394,7 +394,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val issues = issuesOnBoard1.intersect(issuesOnBoard2)
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue2")
+            assertNamesExactly(issues, "issue2")
         }
     }
 
@@ -417,7 +417,7 @@ class YTDBStoreTransactionTest : OTestMixin {
             val issues = issuesOnBoard1.union(issuesOnBoard2)
 
             // Then
-            assertNamesExactlyInOrder(issues, "issue1", "issue2")
+            assertNamesExactly(issues, "issue1", "issue2")
         }
     }
 
@@ -459,7 +459,6 @@ class YTDBStoreTransactionTest : OTestMixin {
 
             // Then
             // As sorted by project name
-            // ToDo: should be fixed with https://youtrack.jetbrains.com/issue/XD-1010
             assertNamesExactlyInOrder(issuesAsc, "issue1", "issue2", "issue3")
             assertNamesExactlyInOrder(issuesDesc, "issue3", "issue2", "issue1")
         }
@@ -494,10 +493,11 @@ class YTDBStoreTransactionTest : OTestMixin {
                 true, // is multiple
                 Issues.Links.IN_PROJECT, // link name
                 issues // entities
-            )
+            ).distinct().toList()
 
             // Then
-            assertNamesExactlyInOrder(issuesAsc, "issue3", "issue2", "issue1")
+            assertNamesExactly(issuesAsc.take(1), "issue1")
+            assertNamesExactly(issuesAsc.drop(1), "issue2", "issue3")
         }
     }
 
@@ -558,7 +558,7 @@ class YTDBStoreTransactionTest : OTestMixin {
         withStoreTx { tx ->
             val issues = tx.findIds(Issues.CLASS, 2, 100) as YTDBEntityIterableBase
             // Then
-            assertNamesExactlyInOrder(
+            assertNamesExactly(
                 issues,
                 test.issue2.getProperty("name").toString(),
                 test.issue3.getProperty("name").toString()

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionTest.kt
@@ -735,27 +735,6 @@ class YTDBStoreTransactionTest : OTestMixin {
         }
     }
 
-//    @Test
-//    fun `active session still has an active transaction after flush`() {
-//        assertFailsWith<DatabaseException> { DatabaseRecordThreadLocal.instance().get() }
-//        withStoreTx { tx ->
-//            DatabaseRecordThreadLocal.instance().get().requireActiveTransaction()
-//            tx.flush()
-//            DatabaseRecordThreadLocal.instance().get().requireActiveTransaction()
-//        }
-//    }
-
-//    @Test
-//    fun `transactionId does not get changed on flush()`() {
-//        withStoreTx { tx ->
-//            val oTransactionId =
-//                DatabaseRecordThreadLocal.instance().get().transaction.id
-//            assertEquals(oTransactionId, tx.getTransactionId())
-//            tx.flush()
-//            assertEquals(oTransactionId, tx.getTransactionId())
-//        }
-//    }
-
     @Test
     fun `deactivate, activate transactions`() {
         // TX1

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableTest.kt
@@ -130,7 +130,7 @@ class YTDBEntityIterableTest : OTestMixin {
                 expectedSql = "SELECT FROM Issue WHERE (name = :name0 OR name = :name1)",
                 expectedParams = mapOf("name0" to "issue1", "name1" to "issue2")
             )
-            assertNamesExactlyInOrder(issues, "issue1", "issue2")
+            assertNamesExactly(issues, "issue1", "issue2")
         }
     }
 
@@ -153,7 +153,7 @@ class YTDBEntityIterableTest : OTestMixin {
                 expectedParams = mapOf("name0" to "issue1", "name1" to "issue1")
             )
             // Union operation can distinct result set if query is optimized to OR conditions
-            assertNamesExactlyInOrder(issues, "issue1")
+            assertNamesExactly(issues, "issue1")
         }
     }
 
@@ -292,7 +292,7 @@ class YTDBEntityIterableTest : OTestMixin {
                 expectedSql = "SELECT DISTINCT * FROM (SELECT expand(unionall(\$a0, \$b0).asSet()) LET \$a0=(SELECT FROM (SELECT expand(in('OnBoard_link')) FROM [${test.board1.id.asOId()}]) WHERE @class='Issue'), \$b0=(SELECT FROM (SELECT expand(in('OnBoard_link')) FROM [${test.board2.id.asOId()}]) WHERE @class='Issue'))"
             )
             assertThat(issuesDistinct).hasSize(3)
-            assertNamesExactlyInOrder(issuesDistinct, "issue1", "issue2", "issue3")
+            assertNamesExactly(issuesDistinct, "issue1", "issue2", "issue3")
         }
     }
 

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableTest.kt
@@ -592,7 +592,7 @@ class YTDBEntityIterableTest : OTestMixin {
         youTrackDb.provider.acquireSession().use { session ->
             val subIssue = session.getOrCreateVertexClass("ChildIssue")
             val issueClass = session.getOrCreateVertexClass(Issues.CLASS)
-            subIssue.setSuperClasses(listOf(issueClass))
+            subIssue.addSuperClass(issueClass)
         }
         (1..10).forEach {
             youTrackDb.createIssue("issue$it")

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableTest.kt
@@ -62,7 +62,7 @@ class YTDBEntityIterableTest : OTestMixin {
                 expectedSql = "SELECT FROM Issue WHERE none is null"
             )
 
-            assertNamesExactlyInOrder(issues, "issue2", "issue3")
+            assertNamesExactly(issues, "issue2", "issue3")
         }
     }
 
@@ -84,7 +84,7 @@ class YTDBEntityIterableTest : OTestMixin {
                 expectedSql = "SELECT FROM Issue WHERE outE('InProject_link').size() == 0"
             )
 
-            assertNamesExactlyInOrder(issues, "issue2", "issue3")
+            assertNamesExactly(issues, "issue2", "issue3")
         }
     }
 
@@ -108,7 +108,7 @@ class YTDBEntityIterableTest : OTestMixin {
                 expectedSql = "SELECT FROM Issue WHERE opca = :opca0",
                 expectedParams = mapOf("opca0" to 300)
             )
-            assertNamesExactlyInOrder(issues, "issue1", "issue3")
+            assertNamesExactly(issues, "issue1", "issue3")
         }
     }
 
@@ -177,7 +177,7 @@ class YTDBEntityIterableTest : OTestMixin {
                 expectedSql = "SELECT FROM Issue WHERE (name = :name0 AND priority = :priority1)",
                 expectedParams = mapOf("name0" to "issue2", "priority1" to "normal")
             )
-            assertNamesExactlyInOrder(issues, "issue2")
+            assertNamesExactly(issues, "issue2")
             assertThat(issues.first().getProperty("priority")).isEqualTo("normal")
         }
     }
@@ -237,7 +237,7 @@ class YTDBEntityIterableTest : OTestMixin {
                 expectedSql = "SELECT FROM (SELECT expand(in('OnBoard_link')) FROM [${test.board1.id.asOId()}]) WHERE @class='Issue'",
                 expectedParams = mapOf()
             )
-            assertNamesExactlyInOrder(issues, "issue1", "issue2")
+            assertNamesExactly(issues, "issue1", "issue2")
         }
     }
 
@@ -263,7 +263,7 @@ class YTDBEntityIterableTest : OTestMixin {
                 concat,
                 expectedSql = "SELECT expand(unionall(\$a0, \$b0)) LET \$a0=(SELECT FROM (SELECT expand(in('OnBoard_link')) FROM [${test.board1.id.asOId()}]) WHERE @class='Issue'), \$b0=(SELECT FROM (SELECT expand(in('OnBoard_link')) FROM [${test.board2.id.asOId()}]) WHERE @class='Issue')",
             )
-            assertNamesExactlyInOrder(concat, "issue1", "issue2", "issue1")
+            assertNamesExactly(concat, "issue1", "issue2", "issue1")
         }
     }
 
@@ -388,12 +388,12 @@ class YTDBEntityIterableTest : OTestMixin {
 
         // When
         withStoreTx { tx ->
-            val issues = tx.getAll(Issues.CLASS).skip(1) as YTDBSkipEntityIterable
+            val issues = tx.sort(Issues.CLASS, "name", true).skip(1) as YTDBEntityIterable
 
             // Then
             tx.checkSql(
                 issues,
-                expectedSql = "SELECT FROM Issue SKIP 1"
+                expectedSql = "SELECT FROM Issue ORDER BY name ASC SKIP 1"
             )
             assertNamesExactlyInOrder(issues, "issue2", "issue3")
         }
@@ -406,12 +406,12 @@ class YTDBEntityIterableTest : OTestMixin {
 
         // When
         withStoreTx { tx ->
-            val issues = tx.getAll(Issues.CLASS).take(2) as YTDBTakeEntityIterable
+            val issues = tx.sort(Issues.CLASS, "name", true).take(2) as YTDBTakeEntityIterable
 
             // Then
             tx.checkSql(
                 issues,
-                expectedSql = "SELECT FROM Issue LIMIT 2"
+                expectedSql = "SELECT FROM Issue ORDER BY name ASC LIMIT 2"
             )
             assertNamesExactlyInOrder(issues, "issue1", "issue2")
         }
@@ -424,12 +424,12 @@ class YTDBEntityIterableTest : OTestMixin {
 
         // When
         withStoreTx { tx ->
-            val issues = tx.getAll(Issues.CLASS).skip(1).take(2) as YTDBTakeEntityIterable
+            val issues = tx.sort(Issues.CLASS, "name", true).skip(1).take(2) as YTDBTakeEntityIterable
 
             // Then
             tx.checkSql(
                 issues,
-                expectedSql = "SELECT FROM Issue SKIP 1 LIMIT 2"
+                expectedSql = "SELECT FROM Issue ORDER BY name ASC SKIP 1 LIMIT 2"
             )
             assertNamesExactlyInOrder(issues, "issue2", "issue3")
         }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableTest.kt
@@ -592,7 +592,7 @@ class YTDBEntityIterableTest : OTestMixin {
         youTrackDb.provider.acquireSession().use { session ->
             val subIssue = session.getOrCreateVertexClass("ChildIssue")
             val issueClass = session.getOrCreateVertexClass(Issues.CLASS)
-            subIssue.setSuperClasses(session, listOf(issueClass))
+            subIssue.setSuperClasses(listOf(issueClass))
         }
         (1..10).forEach {
             youTrackDb.createIssue("issue$it")

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/InMemoryYouTrackDB.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/InMemoryYouTrackDB.kt
@@ -96,9 +96,6 @@ class InMemoryYouTrackDB(
             }
             return result
         } finally {
-//            if (!session.hasActiveTransaction()) {
-//                session.rollback()
-//            }
             if (!session.isClosed) {
                 session.close()
             }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/InMemoryYouTrackDB.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/InMemoryYouTrackDB.kt
@@ -89,16 +89,16 @@ class InMemoryYouTrackDB(
     fun <R> withTxSession(block: (DatabaseSession) -> R): R {
         val session = provider.acquireSession()
         try {
-            session.begin()
+            val tx = session.begin()
             val result = block(session)
             if (session.hasActiveTransaction()) {
-                session.commit()
+                tx.commit()
             }
             return result
         } finally {
-            if (!session.hasActiveTransaction()) {
-                session.rollback()
-            }
+//            if (!session.hasActiveTransaction()) {
+//                session.rollback()
+//            }
             if (!session.isClosed) {
                 session.close()
             }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/OUsersWithInheritanceTestCase.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/OUsersWithInheritanceTestCase.kt
@@ -44,9 +44,7 @@ class OUsersWithInheritanceTestCase(youTrackDB: InMemoryYouTrackDB) {
                 session.getOrCreateVertexClass(Admin.CLASS),
                 session.getOrCreateVertexClass(Agent.CLASS),
             )
-            subclasses.forEach {
-                it.addSuperClass(session, baseClass)
-            }
+            subclasses.forEach { it.addSuperClass(baseClass) }
         }
 
         val tx = youTrackDB.store.beginTransaction() as YTDBStoreTransactionImpl

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/OrientDBIssues.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/testutil/OrientDBIssues.kt
@@ -111,15 +111,15 @@ internal fun DatabaseSession.addAssociation(
     inPropName: String
 ) {
     val fromClass =
-        getClass(fromClassName) ?: throw IllegalStateException("$fromClassName not found")
-    val toClass = getClass(toClassName) ?: throw IllegalStateException("$toClassName not found")
+        schema.getClass(fromClassName) ?: throw IllegalStateException("$fromClassName not found")
+    val toClass = schema.getClass(toClassName) ?: throw IllegalStateException("$toClassName not found")
     val inEdgeName = YTDBVertexEntity.edgeClassName(inPropName)
     val outEdgeName = YTDBVertexEntity.edgeClassName(outPropName)
-    getClass(inEdgeName) ?: this.createEdgeClass(inEdgeName)
-    getClass(outEdgeName) ?: this.createEdgeClass(outEdgeName)
+    schema.getClass(inEdgeName) ?: this.schema.createEdgeClass(inEdgeName)
+    schema.getClass(outEdgeName) ?: this.schema.createEdgeClass(outEdgeName)
 
     val linkInPropName = Vertex.getEdgeLinkFieldName(Direction.IN, inEdgeName)
     val linkOutPropName = Vertex.getEdgeLinkFieldName(Direction.OUT, outEdgeName)
-    fromClass.createProperty(this, linkOutPropName, PropertyType.LINKBAG)
-    toClass.createProperty(this, linkInPropName, PropertyType.LINKBAG)
+    fromClass.createProperty(linkOutPropName, PropertyType.LINKBAG)
+    toClass.createProperty(linkInPropName, PropertyType.LINKBAG)
 }

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrient.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrient.kt
@@ -59,7 +59,7 @@ fun main() {
     val orientDatabaseType = if (orientDatabaseTypeStr.isNullOrBlank() || orientDatabaseTypeStr.lowercase() == "memory") {
         DatabaseType.MEMORY
     } else {
-        DatabaseType.PLOCAL
+        DatabaseType.DISK
     }
     val orientDatabaseDirectory = if (orientDatabaseType == DatabaseType.MEMORY) {
         "memory"

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/Utils.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/Utils.kt
@@ -34,13 +34,13 @@ fun <R> PersistentEntityStore.withReadonlyTx(block: (StoreTransaction) -> R): R 
 }
 
 fun <R> DatabaseSession.withTx(block: (DatabaseSession) -> R): R {
-    this.begin()
+    val tx = this.begin()
     try {
         val result = block(this)
-        this.commit()
+        tx.commit()
         return result
     } catch(e: Throwable) {
-        this.rollback()
+        tx.rollback()
         throw e
     }
 }

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigrator.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigrator.kt
@@ -171,15 +171,15 @@ internal class XodusToOrientDataMigrator(
                 log.info { "${entityTypes.size} entity types to copy" }
                 entityTypes.forEachIndexed { i, type ->
                     log.info { "$i $type is being copied" }
-                    val oClass = oSession.getClass(type) ?: oSession.createVertexClass(type)
+                    val oClass = oSession.schema.getClass(type) ?: oSession.schema.createVertexClass(type)
                     val classId = xodus.getEntityTypeId(type)
 
-                    oClass.setCustom(oSession, CLASS_ID_CUSTOM_PROPERTY_NAME, classId.toString())
+                    oClass.setCustom(CLASS_ID_CUSTOM_PROPERTY_NAME, classId.toString())
                     maxClassId = maxOf(maxClassId, classId)
 
                     // create localEntityId property if absent
                     if (oClass.getProperty(LOCAL_ENTITY_ID_PROPERTY_NAME) == null) {
-                        oClass.createProperty(oSession, LOCAL_ENTITY_ID_PROPERTY_NAME,PropertyType.LONG)
+                        oClass.createProperty(LOCAL_ENTITY_ID_PROPERTY_NAME,PropertyType.LONG)
                     }
                 }
                 entityClassesCount = entityTypes.size
@@ -286,8 +286,8 @@ internal class XodusToOrientDataMigrator(
         orientProvider.withSession { oSession ->
             edgeClassesToCreate.forEachIndexed { i, edgeClassName ->
                 log.info { "$i $edgeClassName ${edgeClassName.asEdgeClass} is being copied" }
-                oSession.getClass(edgeClassName.asEdgeClass)
-                    ?: oSession.createEdgeClass(edgeClassName.asEdgeClass)
+                oSession.schema.getClass(edgeClassName.asEdgeClass)
+                    ?: oSession.schema.createEdgeClass(edgeClassName.asEdgeClass)
             }
         }
         log.info { "${edgeClassesToCreate.size} edge classes have been created" }

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigratorLauncher.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigratorLauncher.kt
@@ -88,7 +88,7 @@ class XodusToOrientDataMigratorLauncher(
 
         val dbName = orient.orientConfig.databaseName
         val classesCount = dbProvider.withSession { session ->
-            session.schema.getClasses(session).filter { schemaClass -> !schemaClass.name.startsWith("O") }.size
+            session.schema.classes.filter { schemaClass -> !schemaClass.name.startsWith("O") }.size
         }
         if (classesCount > VERTEX_CLASSES_TO_SKIP_MIGRATION) {
             log.info { "There are already $classesCount classes in the database so it's considered as migrated" }

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateDataTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateDataTest.kt
@@ -25,12 +25,9 @@ import jetbrains.exodus.bindings.StringBinding
 import jetbrains.exodus.entitystore.PersistentEntityStore
 import jetbrains.exodus.entitystore.StoreTransaction
 import jetbrains.exodus.entitystore.XodusTestDB
-import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity
+import jetbrains.exodus.entitystore.youtrackdb.*
 import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity.Companion.CLASS_ID_SEQUENCE_NAME
 import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity.Companion.localEntityIdSequenceName
-import jetbrains.exodus.entitystore.youtrackdb.createVertexClassWithClassId
-import jetbrains.exodus.entitystore.youtrackdb.requireClassId
-import jetbrains.exodus.entitystore.youtrackdb.requireLocalEntityId
 import jetbrains.exodus.entitystore.youtrackdb.testutil.InMemoryYouTrackDB
 import jetbrains.exodus.util.ByteArraySizedInputStream
 import jetbrains.exodus.util.LightOutputStream
@@ -488,7 +485,7 @@ class MigrateDataTest {
                         maxLocalEntityId = maxOf(maxLocalEntityId, localEntityId)
                     }
 
-                    oSession.executeInTx { tx ->
+                    oSession.transaction { tx ->
                         for (oEntity in tx.query("select from $type").vertexStream()) {
                             val testId = oEntity.getTestId()
                             val localEntityId = oEntity.requireLocalEntityId()

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrientDbSmokeTest.kt
@@ -108,8 +108,8 @@ class MigrateXodusToOrientDbSmokeTest {
 
     private fun YTDBDatabaseProvider.checkSchemaCreated() {
         withSession { session ->
-            val type1 = session.getClass("type1")!!
-            val type2 = session.getClass("type2")!!
+            val type1 = session.schema.getClass("type1")!!
+            val type2 = session.schema.getClass("type2")!!
 
             assertTrue(type1.existsProperty("prop4"))
             assertTrue(type1.existsProperty(Vertex.getEdgeLinkFieldName(Direction.IN, "link1".asEdgeClass)))

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
@@ -300,8 +300,8 @@ internal fun Vertex.addIndexedEdge(linkName: String, target: Vertex) {
 }
 
 internal fun Vertex.deleteIndexedEdge(linkName: String, target: Vertex) {
-    val bag = getTargetLocalEntityIds(linkName)
+//    val bag = getTargetLocalEntityIds(linkName)
     target.delete()
-    bag.remove(target.identity)
-    setTargetLocalEntityIds(linkName, bag)
+//    bag.remove(target.identity)
+//    setTargetLocalEntityIds(linkName, bag)
 }

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/SchemaTestUtils.kt
@@ -300,8 +300,13 @@ internal fun Vertex.addIndexedEdge(linkName: String, target: Vertex) {
 }
 
 internal fun Vertex.deleteIndexedEdge(linkName: String, target: Vertex) {
-//    val bag = getTargetLocalEntityIds(linkName)
-    target.delete()
-//    bag.remove(target.identity)
-//    setTargetLocalEntityIds(linkName, bag)
+    val bag = getTargetLocalEntityIds(linkName)
+
+    for (e in getEdges(Direction.OUT, YTDBVertexEntity.edgeClassName(linkName))) {
+        if (e.toLink?.identity == target.identity) {
+            e.delete()
+        }
+    }
+    bag.remove(target.identity)
+    setTargetLocalEntityIds(linkName, bag)
 }

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/YouTrackDbSchemaInitializerLinkIndicesTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/YouTrackDbSchemaInitializerLinkIndicesTest.kt
@@ -18,6 +18,9 @@ package jetbrains.exodus.query.metadata
 import com.jetbrains.youtrack.db.api.exception.RecordDuplicatedException
 import com.jetbrains.youtrack.db.api.record.Direction
 import com.jetbrains.youtrack.db.api.record.Vertex
+import jetbrains.exodus.entitystore.EntityId
+import jetbrains.exodus.entitystore.youtrackdb.RIDEntityId
+import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity
 import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity.Companion.edgeClassName
 import jetbrains.exodus.entitystore.youtrackdb.YTDBVertexEntity.Companion.linkTargetEntityIdPropertyName
 import jetbrains.exodus.entitystore.youtrackdb.getTargetLocalEntityIds


### PR DESCRIPTION
Migration to the new version of YouTrackDB.
1. No thread bound sessions
2. Dirty entity tracking = no "save()" method anymore
3. Clusters renamed to Collections
4. Changes in embedded/lined collections management
5. Other minor API changes