### PR TITLE
Closing YTDB result sets after querying

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBStoreTransactionImpl.kt
@@ -16,7 +16,6 @@
 package jetbrains.exodus.entitystore.youtrackdb
 
 import com.jetbrains.youtrack.db.api.DatabaseSession
-import com.jetbrains.youtrack.db.api.common.BasicDatabaseSession
 import com.jetbrains.youtrack.db.api.common.BasicDatabaseSession.STATUS
 import com.jetbrains.youtrack.db.api.exception.ModificationOperationProhibitedException
 import com.jetbrains.youtrack.db.api.exception.RecordNotFoundException

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBVertexEntity.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBVertexEntity.kt
@@ -515,9 +515,9 @@ open class YTDBVertexEntity(vertex: Vertex, private val store: YTDBEntityStore) 
     private fun YTDBStoreTransaction.findEdge(edgeClassName: String, targetId: RID): Edge? {
         val query =
             "SELECT FROM $edgeClassName WHERE outV() = :outId AND inV() = :inId"
-        val result = query(query, mapOf("outId" to vertex.identity, "inId" to targetId))
-        val foundEdge = result.edgeStream().findFirst()
-        return foundEdge.getOrNull()
+        return query(query, mapOf("outId" to vertex.identity, "inId" to targetId))
+            .use { it.edgeStream().findFirst() }
+            .getOrNull()
     }
 
     override fun compareTo(other: Entity) = id.compareTo(other.id)

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBQueryEntityIterator.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBQueryEntityIterator.kt
@@ -25,16 +25,16 @@ import jetbrains.exodus.entitystore.youtrackdb.query.YTDBQueryTimeoutException
 import jetbrains.exodus.entitystore.youtrackdb.toEntityIterator
 
 
-class YTDBQueryEntityIterator(private val source: Iterator<Entity>) : EntityIterator {
+class YTDBQueryEntityIterator(private val source: Iterator<Entity>, private val disposeResources: () -> Unit) : EntityIterator {
 
     companion object {
 
-        val EMPTY = YTDBQueryEntityIterator(emptyList<Entity>().iterator())
+        val EMPTY = YTDBQueryEntityIterator(emptyList<Entity>().iterator()) {}
 
         fun executeAndCreate(query: YTDBQuery, txn: YTDBStoreTransaction): YTDBQueryEntityIterator {
             val resultSet = YTDBQueryExecution.execute(query, txn)
             val iterator = resultSet.toEntityIterator(txn.getOEntityStore())
-            return YTDBQueryEntityIterator(iterator)
+            return YTDBQueryEntityIterator(iterator) { resultSet.close() }
         }
     }
 
@@ -61,6 +61,7 @@ class YTDBQueryEntityIterator(private val source: Iterator<Entity>) : EntityIter
     }
 
     override fun dispose(): Boolean {
+        disposeResources()
         return true
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryFunctions.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryFunctions.kt
@@ -124,7 +124,9 @@ class YTDBCountSelect(
         builder.append(")")
     }
 
-    fun count(tx: YTDBStoreTransaction): Long = YTDBQueryExecution.execute(this, tx).next().getLong("count")!!
+    fun count(tx: YTDBStoreTransaction): Long =
+        YTDBQueryExecution.execute(this, tx)
+            .use { it.next().getLong("count") }!!
 }
 
 class YTDBFirstSelect(


### PR DESCRIPTION
Closing YTDB result sets after usage. This can make sense during big transactions that perform dozens of queries.