### PR TITLE
YTDBQueryEntityIterator.shouldDispose=true

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBQueryEntityIterator.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBQueryEntityIterator.kt
@@ -66,7 +66,7 @@ class YTDBQueryEntityIterator(private val source: Iterator<Entity>, private val 
     }
 
     override fun shouldBeDisposed(): Boolean {
-        return false
+        return true
     }
 
     override fun remove() {


### PR DESCRIPTION
YTDBQueryEntityIterator always has a ResultSet associated with it which needs to be disposed after usage.