### PR TITLE
Fixing logic in YTDBEntityIterableBase#isEmpty

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableBase.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableBase.kt
@@ -245,7 +245,7 @@ abstract class YTDBEntityIterableBase(tx: YTDBStoreTransaction) : YTDBEntityIter
     override fun isEmpty(): Boolean {
         val iter = iterator()
         try {
-            return iter.hasNext()
+            return !iter.hasNext()
         } finally {
             iter.dispose()
         }


### PR DESCRIPTION
Fixing my own bug, forgot the negation.