### PR TITLE
Parameterize SQL query components in YouTrackDB queries and update te…

### DIFF
--- a/entity-store/build.gradle.kts
+++ b/entity-store/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     api(project(":xodus-openAPI"))
-    api("io.youtrackdb:youtrackdb-core:1.0.0-20250602.061756-38")
+    api("io.youtrackdb:youtrackdb-core:1.0.0-20250605.144611-39")
 
     implementation(project(":xodus-utils"))
     implementation(project(":xodus-environment"))

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBCondition.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBCondition.kt
@@ -82,7 +82,8 @@ class YTDBEdgeExistsCondition(
 ) : YTDBCondition {
 
     override fun sql(builder: SqlBuilder) {
-        builder.append("outE('").append(edge).append("').size() > 0")
+        val edgeParam = builder.addParam("edge", edge)
+        builder.append("outE(:$edgeParam).size() > 0")
     }
 }
 
@@ -91,7 +92,8 @@ class YTDBEdgeIsNullCondition(
 ) : YTDBCondition {
 
     override fun sql(builder: SqlBuilder) {
-        builder.append("outE('").append(edge).append("').size() == 0")
+        val edgeParam = builder.addParam("edge", edge)
+        builder.append("outE(:$edgeParam).size() == 0")
     }
 }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBLimit.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBLimit.kt
@@ -25,7 +25,8 @@ class YTDBLimitValue(
 ) : YTDBLimit {
 
     override fun sql(builder: SqlBuilder) {
-        builder.append(value)
+        val limitParam = builder.addParam("limit", value)
+        builder.append(":$limitParam")
     }
 
     override fun min(other: YTDBLimit): YTDBLimit {

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBSkip.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBSkip.kt
@@ -26,7 +26,8 @@ class YTDBSkipValue(
 ) : YTDBSkip {
 
     override fun sql(builder: SqlBuilder) {
-        builder.append(value)
+        val skipParam = builder.addParam("skip", value)
+        builder.append(":$skipParam")
     }
 
     override fun min(other: YTDBSkip): YTDBSkip {


### PR DESCRIPTION
To make use of YTDB query caching (and avoid parsing) we need to reduce the variability of the queries by making use of query parameters.