### PR TITLE
Adding the ability to start YouTrackDB server

### DIFF
--- a/entity-store/build.gradle.kts
+++ b/entity-store/build.gradle.kts
@@ -1,6 +1,10 @@
+val ytdbVersion = "1.0.0-20250605.144611-39"
+val ktorVersion = "3.1.3"
+
 dependencies {
     api(project(":xodus-openAPI"))
-    api("io.youtrackdb:youtrackdb-core:1.0.0-20250605.144611-39")
+    api("io.youtrackdb:youtrackdb-core:$ytdbVersion")
+    api("io.youtrackdb:youtrackdb-server:$ytdbVersion")
 
     implementation(project(":xodus-utils"))
     implementation(project(":xodus-environment"))
@@ -12,6 +16,10 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.truth)
     testImplementation(kotlin("test"))
+    testImplementation("io.ktor:ktor-client-core:$ktorVersion")
+    testImplementation("io.ktor:ktor-client-java:$ktorVersion")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
+
 }
 
 val testArtifacts: Configuration by configurations.creating

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseFactory.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseFactory.kt
@@ -16,6 +16,15 @@
 import com.jetbrains.youtrack.db.api.YouTrackDB
 import com.jetbrains.youtrack.db.api.YourTracks
 import com.jetbrains.youtrack.db.internal.core.db.YouTrackDBImpl
+import com.jetbrains.youtrack.db.internal.server.YouTrackDBServer
+import com.jetbrains.youtrack.db.internal.server.network.protocol.binary.NetworkProtocolBinary
+import com.jetbrains.youtrack.db.internal.server.network.protocol.http.NetworkProtocolHttpDb
+import com.jetbrains.youtrack.db.internal.tools.config.ServerConfiguration
+import com.jetbrains.youtrack.db.internal.tools.config.ServerEntryConfiguration
+import com.jetbrains.youtrack.db.internal.tools.config.ServerNetworkConfiguration
+import com.jetbrains.youtrack.db.internal.tools.config.ServerNetworkListenerConfiguration
+import com.jetbrains.youtrack.db.internal.tools.config.ServerNetworkProtocolConfiguration
+import com.jetbrains.youtrack.db.internal.tools.config.ServerUserConfiguration
 import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseParams
 import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProvider
 import jetbrains.exodus.entitystore.youtrackdb.YTDBDatabaseProviderImpl
@@ -36,11 +45,66 @@ object YouTrackDBFactory {
 object YTDBDatabaseProviderFactory {
 
     fun createProvider(params: YTDBDatabaseParams): YTDBDatabaseProvider {
-        val youTrackDb = YouTrackDBFactory.createEmbedded(params)
-        return createProvider(params, youTrackDb)
+
+        val (youTrackDb, server) =
+            if (params.serverParams == null) {
+                Pair(YouTrackDBFactory.createEmbedded(params), null)
+            } else {
+
+                val serverConfig = ServerConfiguration()
+                serverConfig.users = arrayOf(ServerUserConfiguration("root", params.serverParams.rootPassword, "*"))
+                serverConfig.network = ServerNetworkConfiguration().apply {
+                    protocols = mutableListOf()
+                    listeners = mutableListOf()
+                }
+                if (params.serverParams.httpEnabled) {
+                    val ports = params.serverParams.httpPortRange
+                    serverConfig.network.apply {
+                        protocols.add(
+                            ServerNetworkProtocolConfiguration(
+                                "http",
+                                NetworkProtocolHttpDb::class.qualifiedName
+                            )
+                        )
+                        listeners.add(ServerNetworkListenerConfiguration().apply {
+                            ipAddress = "127.0.0.1"
+                            portRange = "${ports.first}-${ports.second}"
+                            protocol = "http"
+                        })
+                    }
+                }
+                if (params.serverParams.binaryEnabled) {
+                    val ports = params.serverParams.binaryPortRange
+                    serverConfig.network.apply {
+                        protocols.add(
+                            ServerNetworkProtocolConfiguration(
+                                "binary",
+                                NetworkProtocolBinary::class.qualifiedName
+                            )
+                        )
+                        listeners.add(ServerNetworkListenerConfiguration().apply {
+                            ipAddress = "127.0.0.1"
+                            portRange = "${ports.first}-${ports.second}"
+                            protocol = "binary"
+                        })
+                    }
+                }
+
+                serverConfig.properties = arrayOf(
+                    ServerEntryConfiguration("log.console.level", params.serverParams.logConsoleLevel),
+                    ServerEntryConfiguration("log.file.level", params.serverParams.logFileLevel),
+                    ServerEntryConfiguration("server.database.path", params.databasePath),
+                )
+
+                val server = YouTrackDBServer(false)
+                server.startup(serverConfig)
+                server.activate()
+                Pair(server.context, server)
+            }
+        return YTDBDatabaseProviderImpl(params, youTrackDb, server)
     }
 
     fun createProvider(params: YTDBDatabaseParams, youTrackDB: YouTrackDB): YTDBDatabaseProvider {
-        return YTDBDatabaseProviderImpl(params, youTrackDB)
+        return YTDBDatabaseProviderImpl(params, youTrackDB, server = null)
     }
 }

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseParams.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseParams.kt
@@ -32,6 +32,7 @@ class YTDBDatabaseParams private constructor(
     val encryptionKey: String?,
     val closeDatabaseInDbProvider: Boolean,
     val closeAfterDelayTimeout: Int,
+    val serverParams: YTDBServerParams? = null,
     val configBuilder: YouTrackDBConfigBuilder.() -> Unit = {}
 ) {
 
@@ -62,6 +63,7 @@ class YTDBDatabaseParams private constructor(
         private var closeAfterDelayTimeout: Int = 10
         private var encryptionKey: String? = null
         private var closeDatabaseInDbProvider = true
+        private var serverParams: YTDBServerParams? = null
         private var configBuilder: YouTrackDBConfigBuilder.() -> Unit = {}
 
         fun withDatabasePath(databaseUrl: String) = apply {
@@ -113,6 +115,10 @@ class YTDBDatabaseParams private constructor(
             this.configBuilder = tweakConfig
         }
 
+        fun withServerParams(serverParams: YTDBServerParams) = apply {
+            this.serverParams = serverParams
+        }
+
         fun build(): YTDBDatabaseParams {
             return YTDBDatabaseParams(
                 databasePath,
@@ -123,6 +129,7 @@ class YTDBDatabaseParams private constructor(
                 encryptionKey,
                 closeDatabaseInDbProvider,
                 closeAfterDelayTimeout,
+                serverParams,
                 configBuilder
             )
         }
@@ -134,5 +141,15 @@ class YTDBDatabaseParams private constructor(
         }
     }
 }
+
+data class YTDBServerParams(
+    val rootPassword: String,
+    val httpEnabled: Boolean = false,
+    val httpPortRange: Pair<Int, Int> = Pair(2480, 2490),
+    val binaryEnabled: Boolean = false,
+    val binaryPortRange: Pair<Int, Int> = Pair(2424, 2430),
+    val logConsoleLevel: String = "info",
+    val logFileLevel: String = "fine",
+)
 
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBDatabaseProviderImpl.kt
@@ -17,7 +17,7 @@ package jetbrains.exodus.entitystore.youtrackdb
 
 import com.jetbrains.youtrack.db.api.DatabaseSession
 import com.jetbrains.youtrack.db.api.YouTrackDB
-import com.jetbrains.youtrack.db.internal.core.db.DatabaseSessionInternal
+import com.jetbrains.youtrack.db.internal.server.YouTrackDBServer
 import java.io.File
 
 //username and password are considered to be same for all databases
@@ -25,6 +25,7 @@ import java.io.File
 class YTDBDatabaseProviderImpl(
     private val params: YTDBDatabaseParams,
     private val database: YouTrackDB,
+    private val server: YouTrackDBServer?
 ) : YTDBDatabaseProvider {
 
     override var isOpen: Boolean = false
@@ -90,10 +91,14 @@ class YTDBDatabaseProviderImpl(
 
     override fun close() {
         isOpen = false
-        // OxygenDB cannot close the database if it is read-only (frozen)
+        // YouTrackDB cannot close the database if it is read-only (frozen)
         readOnly = false
         if (params.closeDatabaseInDbProvider) {
-            database.close()
+            if (server != null) {
+                server.shutdown()
+            } else {
+                database.close()
+            }
         }
     }
 }

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBServerTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/YTDBServerTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright ${inceptionYear} - ${year} ${owner}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.exodus.entitystore.youtrackdb
+
+import YTDBDatabaseProviderFactory
+import com.google.common.truth.Truth.assertThat
+import com.jetbrains.youtrack.db.api.DatabaseType
+import com.jetbrains.youtrack.db.api.YourTracks
+import com.jetbrains.youtrack.db.api.config.YouTrackDBConfig
+import com.jetbrains.youtrack.db.api.exception.DatabaseException
+import com.jetbrains.youtrack.db.api.remote.RemoteDatabaseSession
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import kotlin.io.path.absolutePathString
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.fail
+
+class YTDBServerTest {
+
+    val username = "admin"
+    val password = "admin_password"
+    val rootPassword = "root_password"
+    val dbName = "testDB"
+    lateinit var httpClient: HttpClient
+
+    @BeforeTest
+    fun setup() {
+        httpClient = HttpClient()
+
+    }
+
+    @AfterTest
+    fun tearDown() {
+        httpClient.close()
+    }
+
+    @Test
+    fun dbWithServerNew() {
+
+        val dbPath = Files.createTempDirectory("YTDBServerTest_new").absolutePathString()
+
+        val params = YTDBDatabaseParams.builder()
+            .withDatabaseType(DatabaseType.DISK)
+            .withDatabasePath(dbPath)
+            .withPassword(password)
+            .withUserName(username)
+            .withDatabaseName(dbName)
+            .withServerParams(
+                YTDBServerParams(
+                    rootPassword = rootPassword,
+                    httpEnabled = true,
+                    binaryEnabled = true,
+                )
+            )
+            .build()
+
+        val db = YTDBDatabaseProviderFactory.createProvider(params)
+
+        db.acquireSession().use { session ->
+            session.schema.createVertexClass("Test")
+            session.transaction { tx ->
+                repeat(100) {
+                    tx.newVertex("Test")
+                }
+            }
+        }
+
+        assertThat(remoteEntityCount("Test")).isEqualTo(100)
+        assertThat(httpEntityCount("Test")).isEqualTo(100)
+        db.close()
+
+        checkServerDown()
+    }
+
+    @Test
+    fun dbWithServerExisting() {
+
+        val dbPath = Files.createTempDirectory("YTDBServerTest_existing").absolutePathString()
+
+        val params = YTDBDatabaseParams.builder()
+            .withDatabaseType(DatabaseType.DISK)
+            .withDatabasePath(dbPath)
+            .withPassword(password)
+            .withUserName(username)
+            .withDatabaseName(dbName)
+
+        val dbNoServer = YTDBDatabaseProviderFactory.createProvider(params.build())
+        dbNoServer.acquireSession().use { session ->
+            session.schema.createVertexClass("Test")
+            session.transaction { tx ->
+                repeat(100) {
+                    tx.newVertex("Test")
+                }
+            }
+        }
+        dbNoServer.close()
+
+        val dbWithServer = YTDBDatabaseProviderFactory.createProvider(
+            params
+                .withServerParams(
+                    YTDBServerParams(
+                        rootPassword = rootPassword,
+                        httpEnabled = true,
+                        binaryEnabled = true
+                    )
+                )
+                .build()
+        )
+        assertThat(remoteEntityCount("Test")).isEqualTo(100)
+        assertThat(httpEntityCount("Test")).isEqualTo(100)
+
+        dbWithServer.acquireSession().use { session ->
+            session.transaction { tx ->
+                assertThat(tx.query("SELECT FROM Test").toList()).hasSize(100)
+            }
+
+            session.transaction { tx ->
+                repeat(100) {
+                    tx.newVertex("Test")
+                }
+            }
+        }
+        assertThat(remoteEntityCount("Test")).isEqualTo(200)
+        assertThat(httpEntityCount("Test")).isEqualTo(200)
+        dbWithServer.close()
+
+        checkServerDown()
+    }
+
+    private fun checkServerDown() {
+        try {
+            remoteEntityCount("Test")
+            fail("Server should be down")
+        } catch (e: DatabaseException) {
+            assertThat(e.message).contains("Cannot open database")
+        }
+    }
+
+    private fun remoteSession(): RemoteDatabaseSession {
+        return YourTracks
+            .remote("remote:localhost", "root", rootPassword, YouTrackDBConfig.defaultConfig())
+            .open(dbName, username, password)
+    }
+
+    private fun remoteEntityCount(className: String): Int =
+        remoteSession().use { it.query("SELECT FROM $className").toList().size }
+
+    private fun httpEntityCount(className: String): Int {
+        val query = URLEncoder.encode("SELECT FROM $className", StandardCharsets.UTF_8)
+        val response: String = runBlocking {
+            httpClient
+                .get("http://localhost:2480/query/$dbName/sql/$query/1000") {
+                    basicAuth(username, password)
+                }
+                .bodyAsText()
+        }
+
+        return Json
+            .parseToJsonElement(response).jsonObject
+            .getValue("result").jsonArray
+            .toList()
+            .size
+    }
+}

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrient.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/MigrateXodusToOrient.kt
@@ -113,7 +113,6 @@ fun main() {
         ),
         orient = MigrateToOrientConfig(
             databaseProvider = dbProvider,
-            db = db,
             orientConfig = params,
             true
         ),

--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigratorLauncher.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/XodusToOrientDataMigratorLauncher.kt
@@ -15,7 +15,6 @@
  */
 package jetbrains.exodus.query.metadata
 
-import com.jetbrains.youtrack.db.api.YouTrackDB
 import jetbrains.exodus.entitystore.PersistentEntityStores
 import jetbrains.exodus.entitystore.youtrackdb.*
 import jetbrains.exodus.env.Environments
@@ -36,13 +35,11 @@ val VERTEX_CLASSES_TO_SKIP_MIGRATION = 10
  * Configuration for migrating to OrientDB from another system.
  *
  * @param databaseProvider Provides database connections.
- * @param db Instance of the OrientDB to which data is being migrated.
  * @param orientConfig Configuration settings specific to the OrientDB database.
  * @param closeOnFinish Flag indicating whether to close the database upon completion of migration.
  */
 data class MigrateToOrientConfig(
     val databaseProvider: YTDBDatabaseProvider,
-    val db: YouTrackDB,
     val orientConfig: YTDBDatabaseParams,
     val closeOnFinish: Boolean = false
 )
@@ -237,7 +234,7 @@ class XodusToOrientDataMigratorLauncher(
             xEntityStore.close()
             cleanUpXodusDB(xodus.dropOldDatabaseAfterMigration)
             if (orient.closeOnFinish) {
-                orient.db.close()
+                orient.databaseProvider.close()
             }
         }
     }

--- a/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
+++ b/query/src/test/kotlin/jetbrains/exodus/query/metadata/MigrateYourDatabaseTest.kt
@@ -50,7 +50,6 @@ class MigrateYourDatabaseTest {
         val provider = YTDBDatabaseProviderFactory.createProvider(params, db)
         val launcher = XodusToOrientDataMigratorLauncher(
             orient = MigrateToOrientConfig(
-                db = db,
                 databaseProvider = provider,
                 orientConfig = params,
                 closeOnFinish = true


### PR DESCRIPTION
Now when starting YouTrackDB via YTDBDatabaseProviderFactory it is possible to start YouTrackDB server:

```kotlin
 val params = YTDBDatabaseParams.builder()
 // parameters initialization

 YTDBDatabaseProviderFactory.createProvider(
  params
    .withServerParams(
      YTDBServerParams(
        rootPassword = "root",
        httpEnabled = true,
        binaryEnabled = true
      )
    )
    .build()
)

```