### PR TITLE
COUNT sql query optimization

### DIFF
--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableBase.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/iterate/YTDBEntityIterableBase.kt
@@ -206,10 +206,9 @@ abstract class YTDBEntityIterableBase(tx: YTDBStoreTransaction) : YTDBEntityIter
     private var cachedSize: Long = -1
 
     override fun size(): Long {
-        val currentTx = oStore.requireActiveTransaction()
-        val sourceQuery = query()
-        val countQuery = YTDBCountSelect(sourceQuery.withOrder(EmptyOrder))
-        cachedSize = countQuery.count(currentTx)
+        cachedSize = YTDBQueryExecution
+            .execute(query().count(), oStore.requireActiveTransaction())
+            .use { it.next().getLong("count") }!!
         return cachedSize
     }
 

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryFunctions.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryFunctions.kt
@@ -15,8 +15,6 @@
  */
 package jetbrains.exodus.entitystore.youtrackdb.query
 
-import jetbrains.exodus.entitystore.youtrackdb.YTDBStoreTransaction
-
 object YTDBQueryFunctions {
 
     fun intersect(left: YTDBSelect, right: YTDBSelect): YTDBSelect {
@@ -112,21 +110,6 @@ object YTDBQueryFunctions {
     private fun isSameClassName(left: YTDBClassSelect, right: YTDBClassSelect): Boolean {
         return left.className == right.className
     }
-}
-
-class YTDBCountSelect(
-    val source: YTDBSelect,
-) : YTDBQuery {
-
-    override fun sql(builder: SqlBuilder) {
-        builder.append("SELECT count(*) as count FROM (")
-        source.sql(builder)
-        builder.append(")")
-    }
-
-    fun count(tx: YTDBStoreTransaction): Long =
-        YTDBQueryExecution.execute(this, tx)
-            .use { it.next().getLong("count") }!!
 }
 
 class YTDBFirstSelect(

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBSelect.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBSelect.kt
@@ -17,10 +17,6 @@ package jetbrains.exodus.entitystore.youtrackdb.query
 
 import com.jetbrains.youtrack.db.api.record.RID
 
-interface OConditional {
-    val condition: YTDBCondition?
-}
-
 interface OSortable {
     val order: YTDBOrder?
 
@@ -35,7 +31,12 @@ interface OSizable {
     fun withLimit(limit: Int): YTDBSelect
 }
 
-sealed interface YTDBSelect : YTDBQuery, OSortable, OSizable
+sealed interface YTDBSelect : YTDBQuery, OSortable, OSizable {
+    fun count(): YTDBSelect =
+        if (this is YTDBSelectBase && this.count != null)
+            YTDBSimpleCountSelect(this)
+        else YTDBNestedCountSelect(this)
+}
 
 abstract class YTDBSelectStub(
     override var order: YTDBOrder? = null,
@@ -60,121 +61,114 @@ abstract class YTDBSelectStub(
 }
 
 abstract class YTDBSelectBase(
+    val list: (SqlBuilder.() -> SqlBuilder)?,
+    val count: (SqlBuilder.() -> SqlBuilder)? = null,
+    val from: SqlBuilder.() -> SqlBuilder,
+    val condition: YTDBCondition? = null,
     override var order: YTDBOrder? = null,
     override var skip: YTDBSkip? = null,
-    override var limit: YTDBLimit? = null
+    override var limit: YTDBLimit? = null,
 ) : YTDBSelectStub(order, skip, limit) {
 
-    override fun sql(builder: SqlBuilder) {
-        selectSql(builder)
-        order.orderBy(builder)
-        skip.skip(builder)
-        limit.limit(builder)
-    }
+    final override fun sql(builder: SqlBuilder) {
+        builder.append("SELECT ")
+        list?.let { it(builder).append(" ") }
 
-    abstract fun selectSql(builder: SqlBuilder)
-}
+        builder.append("FROM ")
+        from(builder)
 
-
-class YTDBClassSelect(
-    val className: String,
-    override val condition: YTDBCondition? = null,
-    order: YTDBOrder? = null,
-    skip: YTDBSkip? = null,
-    limit: YTDBLimit? = null
-) : YTDBSelectBase(order, skip, limit), OConditional {
-
-    override fun sql(builder: SqlBuilder) {
-        selectSql(builder)
         condition.where(builder)
         order.orderBy(builder)
         skip.skip(builder)
         limit.limit(builder)
     }
-
-    override fun selectSql(builder: SqlBuilder) {
-        builder.append("SELECT FROM ")
-        builder.append(className)
-    }
 }
+
+class YTDBSimpleCountSelect(
+    source: YTDBSelectBase,
+) : YTDBSelectBase(
+    list = { source.count!!(this).append(" AS count") },
+    from = source.from,
+    condition = source.condition,
+    order = null,
+    skip = source.skip,
+    limit = source.limit,
+)
+
+class YTDBNestedCountSelect(
+    val subQuery: YTDBSelect,
+) : YTDBSelectBase(
+    list = { append("COUNT(*) AS count") },
+    from = { nested(subQuery) }
+)
+
+class YTDBClassSelect(
+    val className: String,
+    where: YTDBCondition? = null,
+    order: YTDBOrder? = null,
+    skip: YTDBSkip? = null,
+    limit: YTDBLimit? = null
+) : YTDBSelectBase(
+    list = null,
+    count = { append("COUNT(*)") },
+    from = { append(className) },
+    condition = where,
+    order = order,
+    skip = skip,
+    limit = limit,
+)
 
 class YTDBLinkInFromSubQuerySelect(
-    val linkName: String,
-    val subQuery: YTDBSelect,
-    order: YTDBOrder? = null,
-    skip: YTDBSkip? = null,
-    limit: YTDBLimit? = null
-) : YTDBSelectBase(order, skip, limit) {
-
-    override fun selectSql(builder: SqlBuilder) {
-        builder.append("SELECT expand(in('$linkName')) FROM (")
-        subQuery.sql(builder)
-        builder.append(")")
-    }
-}
+    linkName: String,
+    subQuery: YTDBSelect,
+) : YTDBSelectBase(
+    list = { inLinks(linkName, expand = true) },
+    count = { inLinks(linkName).append(".size()") },
+    from = { nested(subQuery) }
+)
 
 class YTDBLinkInFromIdsSelect(
-    val linkName: String,
-    val targetIds: List<RID>,
-    order: YTDBOrder? = null,
-    skip: YTDBSkip? = null,
-    limit: YTDBLimit? = null
-) : YTDBSelectBase(order, skip, limit) {
-
-    override fun selectSql(builder: SqlBuilder) {
-        val targetIdsParam = builder.addParam("targetIds", targetIds)
-        builder.append("SELECT expand(in('$linkName')) FROM :$targetIdsParam")
-    }
-}
-
+    linkName: String,
+    targetIds: List<RID>
+) : YTDBSelectBase(
+    list = { inLinks(linkName, expand = true) },
+    count = { inLinks(linkName).append(".size()") },
+    from = { param("targetIds", targetIds) }
+)
 
 class YTDBLinkOfTypeInFromIdsSelect(
-    val linkName: String,
-    val targetIds: List<RID>,
-    val targetEntityType: String,
-    order: YTDBOrder? = null,
-    skip: YTDBSkip? = null,
-    limit: YTDBLimit? = null
-) : YTDBSelectBase(order, skip, limit) {
-
-    override fun selectSql(builder: SqlBuilder) {
-        val targetIdsParam = builder.addParam("targetIds", targetIds)
-        builder
-            .append("SELECT FROM")
-            .append(" (SELECT expand(in('$linkName')) FROM :$targetIdsParam)")
+    linkName: String,
+    targetIds: List<RID>,
+    targetEntityType: String,
+) : YTDBSelectBase(
+    list = null,
+    count = { append("COUNT(*)") },
+    from = {
+        append("(")
+            .append("SELECT ").inLinks(linkName, expand = true)
+            .append(" FROM ").param("targetIds", targetIds)
+            .append(")")
             .append(" WHERE @class='$targetEntityType'")
     }
-}
+)
 
 class YTDBLinkOutFromIdSelect(
     val linkName: String,
-    private val targetIds: List<RID>,
-    order: YTDBOrder? = null,
-    skip: YTDBSkip? = null,
-    limit: YTDBLimit? = null
-) : YTDBSelectBase(order, skip, limit) {
-
-    override fun selectSql(builder: SqlBuilder) {
-        val targetIdsParam = builder.addParam("targetIds", targetIds)
-        builder.append("SELECT expand(out('$linkName')) FROM :$targetIdsParam")
-    }
-}
+    val targetIds: List<RID>,
+) : YTDBSelectBase(
+    list = { outLinks(linkName, expand = true) },
+    count = { outLinks(linkName).append(".size()") },
+    from = { param("targetIds", targetIds) }
+)
 
 class YTDBLinkOutFromSubQuerySelect(
-    val linkName: String,
-    val subQuery: YTDBSelect,
-    order: YTDBOrder? = null,
-    skip: YTDBSkip? = null,
-    limit: YTDBLimit? = null
-) : YTDBSelectBase(order, skip, limit) {
-
-    override fun selectSql(builder: SqlBuilder) {
-        builder.append("SELECT expand(out('$linkName')) FROM (")
-        subQuery.sql(builder)
-        builder.append(")")
-    }
-}
-
+    linkName: String,
+    subQuery: YTDBSelect,
+) : YTDBSelectBase(
+    list = { outLinks(linkName, expand = true) },
+    count = { outLinks(linkName).append(".size()") },
+    from = { nested(subQuery) }
+)
 
 abstract class YTDBBinaryOperationSelect(
     val left: YTDBSelect,
@@ -291,17 +285,10 @@ class YTDBUnionSelect(
 
 class YTDBDistinctSelect(
     val subQuery: YTDBSelect,
-    order: YTDBOrder? = null,
-    skip: YTDBSkip? = null,
-    limit: YTDBLimit? = null
-) : YTDBSelectBase(order, skip, limit) {
-
-    override fun selectSql(builder: SqlBuilder) {
-        builder.append("SELECT DISTINCT * FROM (")
-        subQuery.sql(builder)
-        builder.append(")")
-    }
-}
+) : YTDBSelectBase(
+    list = { append("DISTINCT *") },
+    from = { nested(subQuery) }
+)
 
 class YTDBDifferenceSelect(
     left: YTDBSelect,
@@ -319,13 +306,11 @@ class YTDBDifferenceSelect(
 class YTDBRecordIdSelect(
     val recordIds: Collection<RID>,
     order: YTDBOrder? = null
-) : YTDBSelectBase(order) {
-
-    override fun selectSql(builder: SqlBuilder) {
-        val ridsParam = builder.addParam("rids", recordIds)
-        builder.append("SELECT FROM :$ridsParam")
-    }
-}
+) : YTDBSelectBase(
+    list = null,
+    from = { param("rids", recordIds) },
+    order = order,
+)
 
 fun YTDBCondition?.where(builder: SqlBuilder) {
     this?.let {

--- a/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBSql.kt
+++ b/entity-store/src/main/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBSql.kt
@@ -29,8 +29,38 @@ class SqlBuilder {
         return varCounter++
     }
 
+    fun outLinks(linkName: String, expand: Boolean = false): SqlBuilder =
+        appendLinks("out", linkName, expand)
+
+    fun inLinks(linkName: String, expand: Boolean = false): SqlBuilder =
+        appendLinks("in", linkName, expand)
+
+    private fun appendLinks(linkType: String, linkName: String, expand: Boolean): SqlBuilder {
+        if (expand) {
+            append("expand(")
+        }
+
+        append(linkType).append("('").append(linkName).append("')")
+
+        if (expand) {
+            append(")")
+        }
+
+        return this
+    }
+
     fun append(value: Any): SqlBuilder {
         stringBuilder.append(value)
+        return this
+    }
+
+    fun param(name: String, value: Any): SqlBuilder =
+        append(":").append(addParam(name, value))
+
+    fun nested(sql: YTDBSql): SqlBuilder {
+        stringBuilder.append("(")
+        sql.sql(this)
+        stringBuilder.append(")")
         return this
     }
 

--- a/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryTest.kt
+++ b/entity-store/src/test/kotlin/jetbrains/exodus/entitystore/youtrackdb/query/YTDBQueryTest.kt
@@ -16,6 +16,7 @@
 package jetbrains.exodus.entitystore.youtrackdb.query
 
 import com.google.common.truth.Truth.assertThat
+import com.jetbrains.youtrack.db.internal.core.id.RecordId
 import org.junit.Test
 
 class YTDBQueryTest {
@@ -115,6 +116,26 @@ class YTDBQueryTest {
                 "name1", "John",
                 "name2", "George"
             )
+    }
+
+    @Test
+    fun `should query size() for links`() {
+        val select = YTDBLinkInFromIdsSelect(
+            "linkName",
+            listOf(RecordId(34, 4), RecordId(34, 5))
+        )
+
+        val count = select.count()
+        val query = buildSql(count)
+
+        assertThat(query.sql)
+            .isEqualTo("SELECT in('linkName').size() AS count FROM :targetIds0")
+
+        assertThat(query.params)
+            .containsExactly(
+                "targetIds0", listOf(RecordId(34, 4), RecordId(34, 5))
+            )
+
     }
 
     private fun buildSql(YTDBSql: YTDBSql): SqlQuery {


### PR DESCRIPTION
Optimizing some COUNT query generation for better performance:

`SELECT COUNT(*) FROM (SELECT FROM A)` -> `SELECT COUNT(*) FROM A`
`SELECT COUNT(*) FROM (SELECT expand(in(linkName)) FROM A)` -> `SELECT in(linkName).size() FROM A`
`SELECT COUNT(*) FROM (SELECT expand(out(linkName)) FROM A)` -> `SELECT out(linkName).size() FROM A`