### PR TITLE
XD-1218 IndicesCreator: active tx check differently

### DIFF
--- a/query/src/main/kotlin/jetbrains/exodus/query/metadata/IndicesCreator.kt
+++ b/query/src/main/kotlin/jetbrains/exodus/query/metadata/IndicesCreator.kt
@@ -53,7 +53,7 @@ internal class IndicesCreator(
                             if (!dbSession.schema.indexExists(indexName)) {
                                 val indexType =
                                     if (unique) SchemaClass.INDEX_TYPE.UNIQUE else SchemaClass.INDEX_TYPE.NOTUNIQUE
-                                if (dbSession.isTxActive) {
+                                if (dbSession.activeTransactionOrNull != null) {
                                     val sessionCopy = (dbSession as DatabaseSessionEmbedded).copy()
                                     sessionCopy.use {
                                         val copySessionClass = sessionCopy.schema.getClass(ownerVertexName)


### PR DESCRIPTION
XD-1218 IndicesCreator: active tx check differently. There is a chance that it'll fix the "cannot create index in transaction" error that we have in CK