### PR TITLE
XD-1276 Close full file after sync in endWrite

### DIFF
--- a/environment/src/main/java/jetbrains/exodus/log/BufferedDataWriter.java
+++ b/environment/src/main/java/jetbrains/exodus/log/BufferedDataWriter.java
@@ -237,6 +237,7 @@ public final class BufferedDataWriter {
 
         if (doNeedsToBeSynchronized(currentHighAddress)) {
             doSync(currentHighAddress);
+            closeFullFileAfterSync();
         }
 
         if (blockSetWasChanged) {
@@ -921,38 +922,62 @@ public final class BufferedDataWriter {
 
             assert lastSyncedAddress <= committedHighAddress;
 
-            lastSyncedAddress = committedHighAddress;
-            lastSyncedTs = System.currentTimeMillis();
-
-            writer.close();
-
-            assert blockSetMutable != null;
-
-            var blockSet = blockSetMutable;
-            var lastFile = blockSet.getMaximum();
-            if (lastFile != null) {
-                var block = blockSet.getBlock(lastFile);
-
-                var refreshed = block.refresh();
-                if (block != refreshed) {
-                    blockSet.add(lastFile, refreshed);
-                }
-
-                var length = refreshed.length();
-                if (length < fileLengthBound) {
-                    throw new IllegalStateException(
-                            "File's too short (" + LogUtil.getLogFilename(lastFile)
-                                    + "), block.length() = " + length + ", fileLengthBound = " + fileLengthBound
-                    );
-                }
-
-                if (makeFileReadOnly && block instanceof File) {
-                    //noinspection ResultOfMethodCallIgnored
-                    ((File) block).setReadOnly();
-                }
-            }
+            closeFullFile(fileLengthBound, makeFileReadOnly, committedHighAddress);
         } else if (endPosition > fileLengthBound) {
             throw new ExodusException("endPosition > fileLengthBound: " + endPosition + " > " + fileLengthBound);
+        }
+    }
+
+    /**
+     * The sync performed in {@link #endWrite()} pads the current page (see
+     * {@link #addHashCodeToPage(MutablePage)}) and so can fill the current file up to its boundary. In this case
+     * the file should be closed the same way {@link #closeFileIfNecessary(long, boolean)} closes it after a regular
+     * write, otherwise the writer is left open past the file boundary and the next write fails.
+     * Unlike {@link #closeFileIfNecessary(long, boolean)} this method does not sync (the caller just did) and does
+     * not rely on {@link #committedHighAddress} which is not updated yet at this point of {@link #endWrite()}.
+     */
+    private void closeFullFileAfterSync() {
+        final long fileLengthBound = log.getFileLengthBound();
+        if (!writer.isOpen() || writer.position() != fileLengthBound) {
+            return;
+        }
+
+        assert currentPage.committedCount == currentPage.writtenCount;
+        assert lastSyncedAddress <= currentHighAddress;
+
+        closeFullFile(fileLengthBound, log.getConfig().isFullFileReadonly(), currentHighAddress);
+    }
+
+    private void closeFullFile(long fileLengthBound, boolean makeFileReadOnly, long syncedAddress) {
+        lastSyncedAddress = syncedAddress;
+        lastSyncedTs = System.currentTimeMillis();
+
+        writer.close();
+
+        assert blockSetMutable != null;
+
+        var blockSet = blockSetMutable;
+        var lastFile = blockSet.getMaximum();
+        if (lastFile != null) {
+            var block = blockSet.getBlock(lastFile);
+
+            var refreshed = block.refresh();
+            if (block != refreshed) {
+                blockSet.add(lastFile, refreshed);
+            }
+
+            var length = refreshed.length();
+            if (length < fileLengthBound) {
+                throw new IllegalStateException(
+                        "File's too short (" + LogUtil.getLogFilename(lastFile)
+                                + "), block.length() = " + length + ", fileLengthBound = " + fileLengthBound
+                );
+            }
+
+            if (makeFileReadOnly && block instanceof File) {
+                //noinspection ResultOfMethodCallIgnored
+                ((File) block).setReadOnly();
+            }
         }
     }
 

--- a/environment/src/test/java/jetbrains/exodus/log/LogTests.java
+++ b/environment/src/test/java/jetbrains/exodus/log/LogTests.java
@@ -101,6 +101,48 @@ public class LogTests extends LogTestsBase {
     }
 
     @Test
+    public void testSyncOnEndWritePaddingLastPageOfFile() throws InterruptedException {
+        // Regression test: a sync triggered inside endWrite() (when syncPeriod has elapsed)
+        // pads the current page via addHashCodeToPage() if 17 or fewer bytes are left in it.
+        // If that page is the last page of a file, the padding fills the file up to
+        // fileLengthBound, and the file must be closed exactly as if a regular write had
+        // reached the boundary. Otherwise the next write goes past the file boundary and fails
+        // with "endPosition > fileLengthBound".
+        initLog(new LogConfig().setFileSize(1).setCachePageSize(1024).setSyncPeriod(1));
+
+        final long fileLengthBound = getLog().getFileLengthBound();
+        Assert.assertEquals(1024, fileLengthBound);
+
+        final Loggable emptyLoggable = NullLoggable.create();
+        final int adjustedPageSize = 1024 - BufferedDataWriter.HASH_CODE_SIZE;
+
+        getLog().beginWrite();
+        var expired = ExpiredLoggableCollection.newInstance(log);
+        // fill the page (the only page of the first file) so that exactly 17 bytes are left:
+        // 9 bytes before adjustedPageSize plus 8 bytes of the hash code area
+        while (getLog().getWrittenHighAddress() < adjustedPageSize - 9) {
+            getLog().write(emptyLoggable, expired);
+        }
+        Thread.sleep(50); // let syncPeriod (1 ms) elapse so that endWrite() performs sync
+        getLog().endWrite();
+
+        // the padding has filled the first file up to its boundary
+        Assert.assertEquals(fileLengthBound, getLog().getHighAddress());
+
+        getLog().beginWrite();
+        var expired2 = ExpiredLoggableCollection.newInstance(log);
+        // this write must open a new file and not overflow the previous one
+        Assert.assertEquals(fileLengthBound, getLog().write(emptyLoggable, expired2));
+        getLog().flush();
+        getLog().endWrite();
+
+        // depending on timing, endWrite() may append one more hash code record,
+        // so the exact high address is not asserted
+        Assert.assertTrue(getLog().getHighAddress() > fileLengthBound);
+        Assert.assertEquals(2, (int) getLog().getNumberOfFiles());
+    }
+
+    @Test
     public void testHighestPage() {
         initLog(1, 1024);
 


### PR DESCRIPTION
## Problem

Writes to the Xodus log are followed by BufferedDataWriter#closeFileIfNecessary, which closes the current segment file when it reaches exactly fileLengthBound and throws ExodusException: endPosition > fileLengthBound if the position ever goes past it. This error was recently observed in production on a YouTrack instance; after it, the transaction fails and the environment switches to read-only mode.

Root cause: one code path advances the write position without the follow-up boundary check: BufferedDataWriter#endWrite → doSync → addHashCodeToPage. When the log sync period (default 10 s) has elapsed at commit, the sync stamps the current page so it's crash-verifiable; if ≤17 bytes are left in the page, it pads the page to its full size instead. If that page is the last page of the segment, the padding fills the file exactly to fileLengthBound, but unlike regular writes nothing closes it. The next write finds the old segment still open and fails with the validation error. The background sync thread can't heal the state because lastSyncedAddress is already up to date.

Reproduces only when three conditions coincide (sync due at commit + last page of a segment + last record ends within the final 9 usable bytes of the page), hence rare and seemingly random in production.

## Fix

- Extracted the file-closing logic from `endWrite()` into `closeFullFile(fileLengthBound, makeFileReadOnly, syncedAddress)`.
- Added `closeFullFileAfterSync()`, called from `endWrite()` right after `doSync()`, which closes the file when the sync has filled it up to its boundary. Unlike `closeFileIfNecessary()` it does not sync again and does not rely on `committedHighAddress` (not yet updated at that point).

## Test

Added `LogTests.testSyncOnEndWritePaddingLastPageOfFile`, which reproduces the boundary-padding scenario: it passes with the fix and fails without it.