### PR TITLE
XD-1277 Wait for worker threads to terminate before reopening directory in crash tests

### DIFF
--- a/lucene-directory-v2/src/test/java/jetbrains/exodus/lucene2/XodusDirectoryBaseTest.java
+++ b/lucene-directory-v2/src/test/java/jetbrains/exodus/lucene2/XodusDirectoryBaseTest.java
@@ -395,12 +395,15 @@ public abstract class XodusDirectoryBaseTest extends BaseDirectoryTestCase {
 
                     final var cb = new CyclicBarrier(numOfThreads);
                     final var futures = new ArrayList<Future<?>>();
+                    final var workersStarted = new CountDownLatch(numOfThreads);
+                    final var workersDone = new CountDownLatch(numOfThreads);
 
                     for (int t = 0; t < numOfThreads; t++) {
                         final var roundId = r;
                         final var threadId = t;
                         futures.add(executor.submit(() -> {
                             try {
+                                workersStarted.countDown();
                                 cb.await();
                                 for (int i = 0; i < numOfIterationsPerThread; i++) {
                                     work.run(dirWrapper, fileNameGen, roundId, threadId, i);
@@ -410,6 +413,8 @@ public abstract class XodusDirectoryBaseTest extends BaseDirectoryTestCase {
                                     log.error("Unexpected exception", e);
                                 }
                                 throw new RuntimeException(e);
+                            } finally {
+                                workersDone.countDown();
                             }
                         }));
                     }
@@ -423,10 +428,25 @@ public abstract class XodusDirectoryBaseTest extends BaseDirectoryTestCase {
                             }
                         }
                     } else {
+                        // a task cancelled before it starts never runs at all, so make sure
+                        // every worker has started before interrupting, otherwise workersDone
+                        // can never reach zero
+                        await(workersStarted, "Worker threads did not start");
                         sleep(interruptAfterMillis);
                         for (Future<?> f : futures) {
                             f.cancel(true);
                         }
+                        // cancel(true) only sets the interrupt flag, which the workers observe
+                        // at the next betweenFileOperations checkpoint. Wait until they actually
+                        // terminate, otherwise an in-flight file operation races with the
+                        // directory close and reopen below: e.g. an XodusIndexOutput.close()
+                        // can move its file into the index after the reopened directory has
+                        // already scanned for orphaned files, and then get interrupted before
+                        // writing the metadata file, planting an orphan that is only cleaned
+                        // on the next reopen. f.get() cannot be used to wait for that: on a
+                        // cancelled future it throws immediately, even while the task body
+                        // is still running.
+                        await(workersDone, "Worker threads did not terminate after interruption");
                     }
 
                     expectedDirContent = dirWrapper.getContent();
@@ -633,6 +653,14 @@ public abstract class XodusDirectoryBaseTest extends BaseDirectoryTestCase {
                     throw e;
                 }
             }
+        }
+    }
+
+    private static void await(CountDownLatch latch, String timeoutMessage) {
+        try {
+            assertTrue(timeoutMessage, latch.await(1, TimeUnit.MINUTES));
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
## Problem

`XodusDirectoryNotEncryptedTest#crash_create` (and the other `crash_*` tests) fail flakily with:

```
java.lang.AssertionError: No more cleanup expected, but some files were cleaned: [.../luceneIndex/file_1_7_94]
```

This is a race in the test harness, not a directory bug. `multiThreadedTest` simulates a crash with `Future.cancel(true)`, but never waits for the worker threads to actually stop — the interrupt flag is only observed at `betweenFileOperations` checkpoints. A still-running worker races with the directory close/reopen:

1. A worker inside `XodusIndexOutput.close()` moves its file into `luceneIndex/` **after** the reopened directory has already scanned for orphaned files (the move also wins the race against the `luceneOutput/` wipe).
2. At the next checkpoint the worker gets `InterruptedIOException`, so the metadata file is never written.
3. The file is now an orphan invisible to the first reopen; only the second reopen cleans it, violating the "no more cleanup expected" assertion.

The `NoSuchFileException` errors from pool threads in the CI log (logged *after* the reopen) are the same stragglers losing the `luceneOutput` wipe race.

## Fix

- Each worker counts down a `workersDone` latch in a `finally` block; the crash branch awaits it after cancelling, before the directory is closed and reopened. `f.get()` cannot be used for this: on a cancelled future it throws immediately, even while the task body is still running.
- A `workersStarted` latch is awaited before sleeping/cancelling: the random interruption delay can be ~0ms, and a future cancelled before its task starts never runs the `finally` block, which would leave `workersDone` hanging.

## Verification

- Full `XodusDirectoryNotEncryptedTest` + `XodusDirectoryEncryptedTest`: 152 tests, all green.
- 5 consecutive stress reruns of all 6 `crash_*` tests: all green. (The stress loop is also what caught the cancelled-before-start issue in the first version of the fix.)