### PR TITLE
Fix integer overflow in IndexInput.slice bounds check

### DIFF
--- a/lucene-directory-v2/src/main/java/jetbrains/exodus/lucene2/XodusCacheDirectory.java
+++ b/lucene-directory-v2/src/main/java/jetbrains/exodus/lucene2/XodusCacheDirectory.java
@@ -854,7 +854,7 @@ public class XodusCacheDirectory extends Directory implements CacheDataProvider 
 
         @Override
         public IndexInput slice(String sliceDescription, long offset, long length) {
-            if (offset < 0 || length < 0 || offset + length > this.length()) {
+            if (offset < 0 || length < 0 || offset > this.length() - length) {
                 throw new IllegalArgumentException("slice() " + sliceDescription +
                         " out of bounds: offset=" + offset + ",length=" + length + ",fileLength=" + this.length() + ": " + this);
             }

--- a/lucene-directory-v2/src/main/java/jetbrains/exodus/lucene2/XodusDirectory.java
+++ b/lucene-directory-v2/src/main/java/jetbrains/exodus/lucene2/XodusDirectory.java
@@ -995,7 +995,7 @@ public class XodusDirectory extends Directory implements CacheDataProvider {
 
         @Override
         public IndexInput slice(String sliceDescription, long offset, long length) {
-            if (offset < 0 || length < 0 || offset + length > this.length()) {
+            if (offset < 0 || length < 0 || offset > this.length() - length) {
                 throw new IllegalArgumentException("slice() " + sliceDescription +
                         " out of bounds: offset=" + offset + ",length=" + length + ",fileLength=" + this.length() + ": " + this);
             }


### PR DESCRIPTION
## Problem

`testSliceOutOfBounds` (inherited from Lucene's `BaseDirectoryTestCase`, newly added by the Lucene 10.5 migration in #320) fails for both `XodusDirectoryNotEncryptedTest` and `XodusDirectoryEncryptedTest`.

The test's last case, `i.slice("slice4", Long.MAX_VALUE - 1, 10)`, expects an `IllegalArgumentException`. The old bounds check:

```java
offset < 0 || length < 0 || offset + length > this.length()
```

computed `offset + length`, which overflows past `Long.MAX_VALUE` and wraps to a negative value, so `negative > fileLength` was `false` and the out-of-bounds slice was accepted instead of rejected.

## Fix

Rewrite the last term without addition:

```java
offset < 0 || length < 0 || offset > this.length() - length
```

`this.length() - length` stays in range for valid inputs, so no overflow occurs. This is algebraically equivalent for normal values and matches Lucene's own overflow-safe guard in `BufferedIndexInput.SlicedIndexInput` (`length > base.length() - offset`).

Applied to both `XodusCacheDirectory` and `XodusDirectory`, which had the identical check.

## Testing

`testSliceOutOfBounds` now passes for both encrypted and non-encrypted variants (verified with the failing seed `ECF9330928C812EE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)